### PR TITLE
Add more methods

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -64,8 +64,8 @@ pub trait Address:
     fn raw_value(&self) -> Self::V;
 
     /// Returns the bitwise and of the address with the given mask.
-    fn mask(&self, mask: Self::V) -> Self {
-        Self::new(self.raw_value() & mask)
+    fn mask(&self, mask: Self::V) -> Self::V {
+        self.raw_value() & mask
     }
 
     /// Returns the offset from this address to the given base address and None if there is

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,10 @@ pub mod endian;
 pub use endian::{Be16, Be32, Be64, BeSize, Le16, Le32, Le64, LeSize};
 
 pub mod guest_memory;
-pub use guest_memory::{GuestAddress, GuestMemory, GuestMemoryRegion, MemoryRegionAddress};
+pub use guest_memory::{
+    Error as GuestMemoryError, GuestAddress, GuestMemory, GuestMemoryRegion, GuestUsize,
+    MemoryRegionAddress, Result as GuestMemoryResult,
+};
 
 #[cfg(feature = "backend-mmap")]
 pub mod mmap;
@@ -42,4 +45,7 @@ pub mod mmap;
 pub use mmap::{GuestMemoryMmap, GuestRegionMmap, MmapRegion};
 
 pub mod volatile_memory;
-pub use volatile_memory::*;
+pub use volatile_memory::{
+    Error as VolatileMemoryError, Result as VolatileMemoryResult, VolatileMemory, VolatileRef,
+    VolatileSlice,
+};

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -22,6 +22,7 @@
 
 use libc;
 use std::io::{self, Read, Write};
+use std::ops::Deref;
 use std::os::unix::io::AsRawFd;
 use std::ptr::null_mut;
 use std::sync::Arc;
@@ -181,8 +182,21 @@ impl GuestRegionMmap {
         }
     }
 
-    fn as_volatile_slice(&self) -> VolatileSlice {
-        self.mapping.as_volatile_slice()
+    /// Convert an absolute address into an address space (GuestMemory)
+    /// to a host pointer, or return None if it is out of bounds.
+    pub fn get_host_address(&self, addr: MemoryRegionAddress) -> Option<*mut u8> {
+        // Not sure why wrapping_offset is not unsafe.  Anyway this
+        // is safe because we've just range-checked addr using check_address.
+        self.check_address(addr)
+            .map(|addr| self.as_ptr().wrapping_offset(addr.raw_value() as isize))
+    }
+}
+
+impl Deref for GuestRegionMmap {
+    type Target = MmapRegion;
+
+    fn deref(&self) -> &MmapRegion {
+        &self.mapping
     }
 }
 
@@ -346,7 +360,7 @@ impl GuestMemoryRegion for GuestRegionMmap {
         self.mapping.len() as GuestUsize
     }
 
-    fn min_addr(&self) -> GuestAddress {
+    fn start_addr(&self) -> GuestAddress {
         self.guest_base
     }
 
@@ -409,7 +423,7 @@ impl GuestMemoryMmap {
             if last
                 .guest_base
                 .checked_add(last.mapping.len() as GuestUsize)
-                .map_or(true, |a| a > range.min_addr())
+                .map_or(true, |a| a > range.start_addr())
             {
                 return Err(MmapError::MemoryRegionOverlap);
             }
@@ -418,6 +432,13 @@ impl GuestMemoryMmap {
         Ok(Self {
             regions: Arc::new(ranges),
         })
+    }
+
+    /// Convert an absolute address into an address space (GuestMemory)
+    /// to a host pointer, or return None if it is out of bounds.
+    pub fn get_host_address(&self, addr: GuestAddress) -> Option<*mut u8> {
+        self.to_region_addr(addr)
+            .and_then(|(r, addr)| r.get_host_address(addr))
     }
 }
 
@@ -430,16 +451,16 @@ impl GuestMemory for GuestMemoryMmap {
 
     fn find_region(&self, addr: GuestAddress) -> Option<&GuestRegionMmap> {
         for region in self.regions.iter() {
-            if addr >= region.min_addr() && addr < region.max_addr() {
+            if addr >= region.start_addr() && addr <= region.end_addr() {
                 return Some(region);
             }
         }
         None
     }
 
-    fn with_regions<F>(&self, cb: F) -> Result<()>
+    fn with_regions<F, E>(&self, cb: F) -> std::result::Result<(), E>
     where
-        F: Fn(usize, &GuestRegionMmap) -> Result<()>,
+        F: Fn(usize, &Self::R) -> std::result::Result<(), E>,
     {
         for (index, region) in self.regions.iter().enumerate() {
             cb(index, region)?;
@@ -447,14 +468,22 @@ impl GuestMemory for GuestMemoryMmap {
         Ok(())
     }
 
-    fn with_regions_mut<F>(&self, mut cb: F) -> Result<()>
+    fn with_regions_mut<F, E>(&self, mut cb: F) -> std::result::Result<(), E>
     where
-        F: FnMut(usize, &GuestRegionMmap) -> Result<()>,
+        F: FnMut(usize, &Self::R) -> std::result::Result<(), E>,
     {
         for (index, region) in self.regions.iter().enumerate() {
             cb(index, region)?;
         }
         Ok(())
+    }
+
+    fn map_and_fold<F, G, T>(&self, init: T, mapf: F, foldf: G) -> T
+    where
+        F: Fn((usize, &Self::R)) -> T,
+        G: Fn(T, T) -> T,
+    {
+        self.regions.iter().enumerate().map(mapf).fold(init, foldf)
     }
 }
 
@@ -525,10 +554,88 @@ mod tests {
         let guest_mem =
             GuestMemoryMmap::new(&[(start_addr1, 0x400), (start_addr2, 0x400)]).unwrap();
         assert_eq!(guest_mem.num_regions(), 2);
+        assert_eq!(guest_mem.end_addr(), GuestAddress(0xbff));
         assert!(guest_mem.find_region(GuestAddress(0x200)).is_some());
         assert!(guest_mem.find_region(GuestAddress(0x600)).is_none());
         assert!(guest_mem.find_region(GuestAddress(0xa00)).is_some());
         assert!(guest_mem.find_region(GuestAddress(0xc00)).is_none());
+    }
+
+    #[test]
+    fn test_address_in_range() {
+        let start_addr1 = GuestAddress(0x0);
+        let start_addr2 = GuestAddress(0x800);
+        let guest_mem =
+            GuestMemoryMmap::new(&[(start_addr1, 0x400), (start_addr2, 0x400)]).unwrap();
+        assert!(guest_mem.address_in_range(GuestAddress(0x200)));
+        assert!(!guest_mem.address_in_range(GuestAddress(0x600)));
+        assert!(guest_mem.address_in_range(GuestAddress(0xa00)));
+        assert!(!guest_mem.address_in_range(GuestAddress(0xc00)));
+    }
+
+    #[test]
+    fn test_check_address() {
+        let start_addr1 = GuestAddress(0x0);
+        let start_addr2 = GuestAddress(0x800);
+        let guest_mem =
+            GuestMemoryMmap::new(&[(start_addr1, 0x400), (start_addr2, 0x400)]).unwrap();
+        assert_eq!(
+            guest_mem.check_address(GuestAddress(0x200)),
+            Some(GuestAddress(0x200))
+        );
+        assert_eq!(guest_mem.check_address(GuestAddress(0x600)), None);
+        assert_eq!(
+            guest_mem.check_address(GuestAddress(0xa00)),
+            Some(GuestAddress(0xa00))
+        );
+        assert_eq!(guest_mem.check_address(GuestAddress(0xc00)), None);
+    }
+
+    #[test]
+    fn test_to_region_addr() {
+        let start_addr1 = GuestAddress(0x0);
+        let start_addr2 = GuestAddress(0x800);
+        let guest_mem =
+            GuestMemoryMmap::new(&[(start_addr1, 0x400), (start_addr2, 0x400)]).unwrap();
+        assert!(guest_mem.to_region_addr(GuestAddress(0x600)).is_none());
+        let (r0, addr0) = guest_mem.to_region_addr(GuestAddress(0x800)).unwrap();
+        let (r1, addr1) = guest_mem.to_region_addr(GuestAddress(0xa00)).unwrap();
+        assert!(r0.as_ptr() == r1.as_ptr());
+        assert_eq!(addr0, MemoryRegionAddress(0));
+        assert_eq!(addr1, MemoryRegionAddress(0x200));
+    }
+
+    #[test]
+    fn test_get_host_address() {
+        let start_addr1 = GuestAddress(0x0);
+        let start_addr2 = GuestAddress(0x800);
+        let guest_mem =
+            GuestMemoryMmap::new(&[(start_addr1, 0x400), (start_addr2, 0x400)]).unwrap();
+        assert!(guest_mem.get_host_address(GuestAddress(0x600)).is_none());
+        let ptr0 = guest_mem.get_host_address(GuestAddress(0x800)).unwrap();
+        let ptr1 = guest_mem.get_host_address(GuestAddress(0xa00)).unwrap();
+        assert_eq!(
+            ptr0,
+            guest_mem.find_region(GuestAddress(0x800)).unwrap().as_ptr()
+        );
+        assert_eq!(unsafe { ptr0.offset(0x200) }, ptr1);
+    }
+
+    #[test]
+    fn test_deref() {
+        let start_addr = GuestAddress(0x0);
+        let guest_mem = GuestMemoryMmap::new(&[(start_addr, 0x400)]).unwrap();
+        let sample_buf = &[1, 2, 3, 4, 5];
+
+        assert_eq!(guest_mem.write(sample_buf, start_addr).unwrap(), 5);
+        let slice = guest_mem
+            .find_region(GuestAddress(0))
+            .unwrap()
+            .as_volatile_slice();
+
+        let buf = &mut [0, 0, 0, 0, 0];
+        assert_eq!(slice.read(buf, 0).unwrap(), 5);
+        assert_eq!(buf, sample_buf);
     }
 
     #[test]
@@ -646,7 +753,7 @@ mod tests {
         assert!(res.is_ok());
 
         let res: Result<()> = gm.with_regions_mut(|_, region| {
-            iterated_regions.push((region.min_addr(), region.len() as usize));
+            iterated_regions.push((region.start_addr(), region.len() as usize));
             Ok(())
         });
         assert!(res.is_ok());


### PR DESCRIPTION
I have noticed some missing methods while trying to port Firecracker to rust-vmm/vm-memory. This pull request adds them.