### PR TITLE
mmap: Export MmapError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ pub use guest_memory::{
 #[cfg(feature = "backend-mmap")]
 pub mod mmap;
 #[cfg(feature = "backend-mmap")]
-pub use mmap::{GuestMemoryMmap, GuestRegionMmap, MmapRegion};
+pub use mmap::{GuestMemoryMmap, GuestRegionMmap, MmapError, MmapRegion};
 
 pub mod volatile_memory;
 pub use volatile_memory::{


### PR DESCRIPTION
mmap callers need this to properly propagate the memory model errors.

Fixes: #11

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>