### PR TITLE
volatile_memory: add VolatileArrayRef and &std::sync::atomic::Atomic* accessors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ backend-mmap = []
 
 [dependencies]
 libc = ">=0.2.39"
+cast = ">=0"
 
 [dev-dependencies]
 matches = ">=0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 
 [features]
 default = []
+integer-atomics = []
 backend-mmap = []
 
 [dependencies]

--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -57,6 +57,7 @@ impl From<volatile_memory::Error> for Error {
         match e {
             volatile_memory::Error::OutOfBounds { .. } => Error::InvalidBackendAddress,
             volatile_memory::Error::Overflow { .. } => Error::InvalidBackendAddress,
+            volatile_memory::Error::TooBig { .. } => Error::InvalidBackendAddress,
             volatile_memory::Error::IOError(e) => Error::IOError(e),
             volatile_memory::Error::PartialBuffer {
                 expected,

--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -58,6 +58,7 @@ impl From<volatile_memory::Error> for Error {
             volatile_memory::Error::OutOfBounds { .. } => Error::InvalidBackendAddress,
             volatile_memory::Error::Overflow { .. } => Error::InvalidBackendAddress,
             volatile_memory::Error::TooBig { .. } => Error::InvalidBackendAddress,
+            volatile_memory::Error::Misaligned { .. } => Error::InvalidBackendAddress,
             volatile_memory::Error::IOError(e) => Error::IOError(e),
             volatile_memory::Error::PartialBuffer {
                 expected,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,6 @@ pub use mmap::{GuestMemoryMmap, GuestRegionMmap, MmapError, MmapRegion};
 
 pub mod volatile_memory;
 pub use volatile_memory::{
-    Error as VolatileMemoryError, Result as VolatileMemoryResult, VolatileMemory, VolatileRef,
-    VolatileSlice,
+    Error as VolatileMemoryError, Result as VolatileMemoryResult, VolatileArrayRef, VolatileMemory,
+    VolatileRef, VolatileSlice,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,6 @@ pub use mmap::{GuestMemoryMmap, GuestRegionMmap, MmapError, MmapRegion};
 
 pub mod volatile_memory;
 pub use volatile_memory::{
-    Error as VolatileMemoryError, Result as VolatileMemoryResult, VolatileArrayRef, VolatileMemory,
-    VolatileRef, VolatileSlice,
+    AtomicValued, Error as VolatileMemoryError, Result as VolatileMemoryResult, VolatileArrayRef,
+    VolatileMemory, VolatileRef, VolatileSlice,
 };

--- a/src/volatile_memory.rs
+++ b/src/volatile_memory.rs
@@ -607,7 +607,7 @@ impl<'a> VolatileMemory for VolatileSlice<'a> {
 ///   assert_eq!(v_ref.load(), 5);
 ///   v_ref.store(500);
 ///   assert_eq!(v, 500);
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct VolatileRef<'a, T: ByteValued>
 where
     T: 'a,
@@ -632,7 +632,7 @@ impl<'a, T: ByteValued> VolatileRef<'a, T> {
     }
 
     /// Gets the address of this slice's memory.
-    pub fn as_ptr(&self) -> *mut u8 {
+    pub fn as_ptr(self) -> *mut u8 {
         self.addr as *mut u8
     }
 
@@ -646,19 +646,19 @@ impl<'a, T: ByteValued> VolatileRef<'a, T> {
     ///   let v_ref = unsafe { VolatileRef::<u32>::new(0 as *mut _) };
     ///   assert_eq!(v_ref.len(), size_of::<u32>() as usize);
     /// ```
-    pub fn len(&self) -> usize {
+    pub fn len(self) -> usize {
         size_of::<T>()
     }
 
     /// Does a volatile write of the value `v` to the address of this ref.
     #[inline(always)]
-    pub fn store(&self, v: T) {
+    pub fn store(self, v: T) {
         unsafe { write_volatile(self.addr, Packed::<T>(v)) };
     }
 
     /// Does a volatile read of the value at the address of this ref.
     #[inline(always)]
-    pub fn load(&self) -> T {
+    pub fn load(self) -> T {
         // For the purposes of demonstrating why read_volatile is necessary, try replacing the code
         // in this function with the commented code below and running `cargo test --release`.
         // unsafe { *(self.addr as *const T) }
@@ -666,7 +666,7 @@ impl<'a, T: ByteValued> VolatileRef<'a, T> {
     }
 
     /// Converts this `T` reference to a raw slice with the same size and address.
-    pub fn to_slice(&self) -> VolatileSlice<'a> {
+    pub fn to_slice(self) -> VolatileSlice<'a> {
         unsafe { VolatileSlice::new(self.addr as *mut u8, size_of::<T>()) }
     }
 }


### PR DESCRIPTION
Allow easily access to an array stored in a VolatileMemory object, removing
the need to do multiplications and pointer offsetting.