### PR TITLE
Another iteration of supporting file backed memory regions

### DIFF
--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -200,6 +200,9 @@ pub trait GuestMemoryRegion: Bytes<MemoryRegionAddress, E = Error> {
             .and_then(|offset| self.check_address(MemoryRegionAddress(offset)))
     }
 
+    /// Returns information regarding the file and offset backing this memory region.
+    fn file_offset(&self) -> Option<&FileOffset>;
+
     /// Return a slice corresponding to the data in the region; unsafe because of
     /// possible aliasing.  Return None if the region does not support slice-based
     /// access.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ mod mmap_windows;
 #[cfg(feature = "backend-mmap")]
 pub mod mmap;
 #[cfg(feature = "backend-mmap")]
-pub use mmap::{GuestMemoryMmap, GuestRegionMmap, MmapError, MmapRegion};
+pub use mmap::{Error, GuestMemoryMmap, GuestRegionMmap, MmapRegion};
 
 pub mod volatile_memory;
 pub use volatile_memory::{

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -26,7 +26,9 @@ use std::result;
 use std::sync::Arc;
 
 use address::Address;
-use guest_memory::*;
+use guest_memory::{
+    self, GuestAddress, GuestMemory, GuestMemoryRegion, GuestUsize, MemoryRegionAddress,
+};
 use volatile_memory::VolatileMemory;
 use Bytes;
 
@@ -46,7 +48,7 @@ pub(crate) trait AsSlice {
 
 /// Errors that can happen when creating a memory map
 #[derive(Debug)]
-pub enum MmapError {
+pub enum Error {
     /// Error creating a `MmapRegion` object.
     MmapRegion(MmapRegionError),
     /// No memory region found.
@@ -116,7 +118,7 @@ impl Deref for GuestRegionMmap {
 }
 
 impl Bytes<MemoryRegionAddress> for GuestRegionMmap {
-    type E = Error;
+    type E = guest_memory::Error;
 
     /// # Examples
     /// * Write a slice at guest address 0x1200.
@@ -128,7 +130,7 @@ impl Bytes<MemoryRegionAddress> for GuestRegionMmap {
     ///   let res = gm.write(&[1,2,3,4,5], GuestAddress(0x1200)).unwrap();
     ///   assert_eq!(5, res);
     /// ```
-    fn write(&self, buf: &[u8], addr: MemoryRegionAddress) -> Result<usize> {
+    fn write(&self, buf: &[u8], addr: MemoryRegionAddress) -> guest_memory::Result<usize> {
         let maddr = addr.raw_value() as usize;
         self.as_volatile_slice()
             .write(buf, maddr)
@@ -146,21 +148,21 @@ impl Bytes<MemoryRegionAddress> for GuestRegionMmap {
     ///   let res = gm.read(buf, GuestAddress(0x1200)).unwrap();
     ///   assert_eq!(16, res);
     /// ```
-    fn read(&self, buf: &mut [u8], addr: MemoryRegionAddress) -> Result<usize> {
+    fn read(&self, buf: &mut [u8], addr: MemoryRegionAddress) -> guest_memory::Result<usize> {
         let maddr = addr.raw_value() as usize;
         self.as_volatile_slice()
             .read(buf, maddr)
             .map_err(Into::into)
     }
 
-    fn write_slice(&self, buf: &[u8], addr: MemoryRegionAddress) -> Result<()> {
+    fn write_slice(&self, buf: &[u8], addr: MemoryRegionAddress) -> guest_memory::Result<()> {
         let maddr = addr.raw_value() as usize;
         self.as_volatile_slice()
             .write_slice(buf, maddr)
             .map_err(Into::into)
     }
 
-    fn read_slice(&self, buf: &mut [u8], addr: MemoryRegionAddress) -> Result<()> {
+    fn read_slice(&self, buf: &mut [u8], addr: MemoryRegionAddress) -> guest_memory::Result<()> {
         let maddr = addr.raw_value() as usize;
         self.as_volatile_slice()
             .read_slice(buf, maddr)
@@ -187,7 +189,12 @@ impl Bytes<MemoryRegionAddress> for GuestRegionMmap {
     ///   let read_addr = addr.checked_add(8).unwrap();
     ///   let _: u32 = gm.read_obj(read_addr).unwrap();
     /// ```
-    fn read_from<F>(&self, addr: MemoryRegionAddress, src: &mut F, count: usize) -> Result<usize>
+    fn read_from<F>(
+        &self,
+        addr: MemoryRegionAddress,
+        src: &mut F,
+        count: usize,
+    ) -> guest_memory::Result<usize>
     where
         F: Read,
     {
@@ -219,7 +226,12 @@ impl Bytes<MemoryRegionAddress> for GuestRegionMmap {
     ///   let read_addr = addr.checked_add(8).unwrap();
     ///   let _: u32 = gm.read_obj(read_addr).unwrap();
     /// ```
-    fn read_exact_from<F>(&self, addr: MemoryRegionAddress, src: &mut F, count: usize) -> Result<()>
+    fn read_exact_from<F>(
+        &self,
+        addr: MemoryRegionAddress,
+        src: &mut F,
+        count: usize,
+    ) -> guest_memory::Result<()>
     where
         F: Read,
     {
@@ -246,7 +258,12 @@ impl Bytes<MemoryRegionAddress> for GuestRegionMmap {
     ///   let mut mem = [0u8; 1024];
     ///   gm.write_to(start_addr, &mut file, 128).unwrap();
     /// ```
-    fn write_to<F>(&self, addr: MemoryRegionAddress, dst: &mut F, count: usize) -> Result<usize>
+    fn write_to<F>(
+        &self,
+        addr: MemoryRegionAddress,
+        dst: &mut F,
+        count: usize,
+    ) -> guest_memory::Result<usize>
     where
         F: Write,
     {
@@ -273,7 +290,12 @@ impl Bytes<MemoryRegionAddress> for GuestRegionMmap {
     ///   let mut mem = [0u8; 1024];
     ///   gm.write_all_to(start_addr, &mut file, 128).unwrap();
     /// ```
-    fn write_all_to<F>(&self, addr: MemoryRegionAddress, dst: &mut F, count: usize) -> Result<()>
+    fn write_all_to<F>(
+        &self,
+        addr: MemoryRegionAddress,
+        dst: &mut F,
+        count: usize,
+    ) -> guest_memory::Result<()>
     where
         F: Write,
     {
@@ -311,9 +333,9 @@ pub struct GuestMemoryMmap {
 impl GuestMemoryMmap {
     /// Creates a container and allocates anonymous memory for guest memory regions.
     /// Valid memory regions are specified as a Vec of (Address, Size) tuples sorted by Address.
-    pub fn new(ranges: &[(GuestAddress, usize)]) -> std::result::Result<Self, MmapError> {
+    pub fn new(ranges: &[(GuestAddress, usize)]) -> result::Result<Self, Error> {
         if ranges.is_empty() {
-            return Err(MmapError::NoMemoryRegion);
+            return Err(Error::NoMemoryRegion);
         }
 
         let mut regions = Vec::<GuestRegionMmap>::new();
@@ -324,11 +346,11 @@ impl GuestMemoryMmap {
                     .checked_add(last.mapping.len() as GuestUsize)
                     .map_or(true, |a| a > range.0)
                 {
-                    return Err(MmapError::MemoryRegionOverlap);
+                    return Err(Error::MemoryRegionOverlap);
                 }
             }
 
-            let mapping = MmapRegion::new(range.1).map_err(MmapError::MmapRegion)?;
+            let mapping = MmapRegion::new(range.1).map_err(Error::MmapRegion)?;
             regions.push(GuestRegionMmap {
                 mapping,
                 guest_base: range.0,
@@ -341,9 +363,9 @@ impl GuestMemoryMmap {
     }
 
     /// Creates a container and adds an existing set of mappings to it.
-    pub fn from_regions(ranges: Vec<GuestRegionMmap>) -> std::result::Result<Self, MmapError> {
+    pub fn from_regions(ranges: Vec<GuestRegionMmap>) -> result::Result<Self, Error> {
         if ranges.is_empty() {
-            return Err(MmapError::NoMemoryRegion);
+            return Err(Error::NoMemoryRegion);
         }
 
         for rangei in 1..ranges.len() {
@@ -354,7 +376,7 @@ impl GuestMemoryMmap {
                 .checked_add(last.mapping.len() as GuestUsize)
                 .map_or(true, |a| a > range.start_addr())
             {
-                return Err(MmapError::MemoryRegionOverlap);
+                return Err(Error::MemoryRegionOverlap);
             }
         }
 
@@ -387,9 +409,9 @@ impl GuestMemory for GuestMemoryMmap {
         None
     }
 
-    fn with_regions<F, E>(&self, cb: F) -> std::result::Result<(), E>
+    fn with_regions<F, E>(&self, cb: F) -> result::Result<(), E>
     where
-        F: Fn(usize, &Self::R) -> std::result::Result<(), E>,
+        F: Fn(usize, &Self::R) -> result::Result<(), E>,
     {
         for (index, region) in self.regions.iter().enumerate() {
             cb(index, region)?;
@@ -397,9 +419,9 @@ impl GuestMemory for GuestMemoryMmap {
         Ok(())
     }
 
-    fn with_regions_mut<F, E>(&self, mut cb: F) -> std::result::Result<(), E>
+    fn with_regions_mut<F, E>(&self, mut cb: F) -> result::Result<(), E>
     where
-        F: FnMut(usize, &Self::R) -> std::result::Result<(), E>,
+        F: FnMut(usize, &Self::R) -> result::Result<(), E>,
     {
         for (index, region) in self.regions.iter().enumerate() {
             cb(index, region)?;
@@ -463,7 +485,7 @@ mod tests {
         // No regions provided should return error.
         assert_eq!(
             format!("{:?}", GuestMemoryMmap::new(&[]).err().unwrap()),
-            format!("{:?}", MmapError::NoMemoryRegion)
+            format!("{:?}", Error::NoMemoryRegion)
         );
 
         let start_addr1 = GuestAddress(0x0);
@@ -578,7 +600,7 @@ mod tests {
         let res = GuestMemoryMmap::new(&[(start_addr1, 0x2000), (start_addr2, 0x2000)]);
         assert_eq!(
             format!("{:?}", res.err().unwrap()),
-            format!("{:?}", MmapError::MemoryRegionOverlap)
+            format!("{:?}", Error::MemoryRegionOverlap)
         );
     }
 
@@ -672,13 +694,13 @@ mod tests {
         let mut iterated_regions = Vec::new();
         let gm = GuestMemoryMmap::new(&regions).unwrap();
 
-        let res: Result<()> = gm.with_regions(|_, region| {
+        let res: guest_memory::Result<()> = gm.with_regions(|_, region| {
             assert_eq!(region.len(), region_size as GuestUsize);
             Ok(())
         });
         assert!(res.is_ok());
 
-        let res: Result<()> = gm.with_regions_mut(|_, region| {
+        let res: guest_memory::Result<()> = gm.with_regions_mut(|_, region| {
             iterated_regions.push((region.start_addr(), region.len() as usize));
             Ok(())
         });

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -38,6 +38,8 @@ pub use mmap_unix::{Error as MmapRegionError, MmapRegion};
 
 #[cfg(windows)]
 pub use mmap_windows::MmapRegion;
+#[cfg(windows)]
+pub use std::io::Error as MmapRegionError;
 
 // For MmapRegion
 pub(crate) trait AsSlice {
@@ -900,7 +902,12 @@ mod tests {
         assert!(region.file_offset().is_some());
     }
 
+    // Windows needs a dedicated test where it will retrieve the allocation
+    // granularity to determine a proper offset (other than 0) that can be
+    // used for the backing file. Refer to Microsoft docs here:
+    // https://docs.microsoft.com/en-us/windows/desktop/api/memoryapi/nf-memoryapi-mapviewoffile
     #[test]
+    #[cfg(unix)]
     fn test_retrieve_offset_from_fd_backing_memory_region() {
         let f = tempfile().unwrap();
         f.set_len(0x1400).unwrap();

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 
 use address::Address;
 use guest_memory::{
-    self, GuestAddress, GuestMemory, GuestMemoryRegion, GuestUsize, MemoryRegionAddress,
+    self, FileOffset, GuestAddress, GuestMemory, GuestMemoryRegion, GuestUsize, MemoryRegionAddress,
 };
 use volatile_memory::VolatileMemory;
 use Bytes;
@@ -49,6 +49,9 @@ pub(crate) trait AsSlice {
 /// Errors that can happen when creating a memory map
 #[derive(Debug)]
 pub enum Error {
+    /// Adding the guest base address to the length of the underlying mapping resulted
+    /// in an overflow.
+    InvalidGuestRegion,
     /// Error creating a `MmapRegion` object.
     MmapRegion(MmapRegionError),
     /// No memory region found.
@@ -91,12 +94,14 @@ pub struct GuestRegionMmap {
 
 impl GuestRegionMmap {
     /// Create a new memory-mapped memory region for guest's physical memory.
-    /// Note: caller needs to ensure that (mapping.len() + guest_base) doesn't wrapping around.
-    pub fn new(mapping: MmapRegion, guest_base: GuestAddress) -> Self {
-        GuestRegionMmap {
+    pub fn new(mapping: MmapRegion, guest_base: GuestAddress) -> result::Result<Self, Error> {
+        if guest_base.0.checked_add(mapping.len() as u64).is_none() {
+            return Err(Error::InvalidGuestRegion);
+        }
+        Ok(GuestRegionMmap {
             mapping,
             guest_base,
-        }
+        })
     }
 
     /// Convert an absolute address into an address space (GuestMemory)
@@ -584,7 +589,7 @@ mod tests {
         assert!(f.write_all(empty_buf).is_ok());
 
         let mem_map = MmapRegion::from_file(FileOffset::new(f, 0), empty_buf.len()).unwrap();
-        let guest_reg = GuestRegionMmap::new(mem_map, GuestAddress(0x8000));
+        let guest_reg = GuestRegionMmap::new(mem_map, GuestAddress(0x8000)).unwrap();
         let mut region_vec = Vec::new();
         region_vec.push(guest_reg);
         let guest_mem = GuestMemoryMmap::from_regions(region_vec).unwrap();

--- a/src/mmap_unix.rs
+++ b/src/mmap_unix.rs
@@ -20,14 +20,33 @@
 //! - [GuestMemoryMmap](struct.GuestMemoryMmap.html): provides methods to access a collection of
 //! GuestRegionMmap objects.
 
-use libc;
 use std::io;
+use std::os::unix::io::AsRawFd;
 use std::ptr::null_mut;
+use std::result;
 
-use mmap::AsSlice;
+use libc;
+
+use guest_memory::FileOffset;
+use mmap::{check_file_offset, AsSlice};
 use volatile_memory::{self, compute_offset, VolatileMemory, VolatileSlice};
 
-use std::os::unix::io::AsRawFd;
+/// Error conditions that may arise when creating a new `MmapRegion` object.
+#[derive(Debug)]
+pub enum Error {
+    /// The specified file offset and length cause overflow when added.
+    InvalidOffsetLength,
+    /// The forbidden `MAP_FIXED` flag was specified.
+    MapFixed,
+    /// Mappings using the same fd overlap in terms of file offset and length.
+    MappingOverlap,
+    /// A mapping with offset + length > EOF was attempted.
+    MappingPastEof,
+    /// The `mmap` call returned an error.
+    Mmap(io::Error),
+}
+
+pub type Result<T> = result::Result<T, Error>;
 
 /// A backend driver to access guest's physical memory by mmapping guest's memory into the current
 /// process.
@@ -38,6 +57,9 @@ use std::os::unix::io::AsRawFd;
 pub struct MmapRegion {
     addr: *mut u8,
     size: usize,
+    file_offset: Option<FileOffset>,
+    prot: i32,
+    flags: i32,
 }
 
 // Send and Sync aren't automatically inherited for the raw address pointer.
@@ -52,53 +74,63 @@ impl MmapRegion {
     ///
     /// # Arguments
     /// * `size` - Size of memory region in bytes.
-    pub fn new(size: usize) -> io::Result<Self> {
-        // This is safe because we are creating an anonymous mapping in a place not already used by
-        // any other area in this process.
-        let addr = unsafe {
-            libc::mmap(
-                null_mut(),
-                size,
-                libc::PROT_READ | libc::PROT_WRITE,
-                libc::MAP_ANONYMOUS | libc::MAP_SHARED | libc::MAP_NORESERVE,
-                -1,
-                0,
-            )
-        };
-        if addr == libc::MAP_FAILED {
-            return Err(io::Error::last_os_error());
-        }
-        Ok(Self {
-            addr: addr as *mut u8,
+    pub fn new(size: usize) -> Result<Self> {
+        Self::build(
+            None,
             size,
-        })
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_ANONYMOUS | libc::MAP_NORESERVE | libc::MAP_PRIVATE,
+        )
     }
 
     /// Maps the `size` bytes starting at `offset` bytes of the given `fd`.
     ///
     /// # Arguments
-    /// * `fd` - File descriptor to mmap from.
+    /// * `file_offset` - File object and offset to mmap from.
     /// * `size` - Size of memory region in bytes.
-    /// * `offset` - Offset in bytes from the beginning of `fd` to start the mmap.
-    pub fn from_fd(fd: &AsRawFd, size: usize, offset: libc::off_t) -> io::Result<Self> {
-        // This is safe because we are creating a mapping in a place not already used by any other
-        // area in this process.
-        let addr = unsafe {
-            libc::mmap(
-                null_mut(),
-                size,
-                libc::PROT_READ | libc::PROT_WRITE,
-                libc::MAP_SHARED,
-                fd.as_raw_fd(),
-                offset,
-            )
-        };
-        if addr == libc::MAP_FAILED {
-            return Err(io::Error::last_os_error());
+    pub fn from_file(file_offset: FileOffset, size: usize) -> Result<Self> {
+        Self::build(
+            Some(file_offset),
+            size,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_NORESERVE | libc::MAP_SHARED,
+        )
+    }
+
+    /// Creates a new mapping based on the provided arguments.
+    pub fn build(
+        file_offset: Option<FileOffset>,
+        size: usize,
+        prot: i32,
+        flags: i32,
+    ) -> Result<Self> {
+        // Forbid MAP_FIXED, as it doesn't make sense in this context, and is pretty dangerous
+        // in general.
+        if flags & libc::MAP_FIXED != 0 {
+            return Err(Error::MapFixed);
         }
+
+        let (fd, offset) = if let Some(ref f_off) = file_offset {
+            check_file_offset(f_off, size)?;
+            (f_off.file().as_raw_fd(), f_off.start())
+        } else {
+            (-1, 0)
+        };
+
+        // This is safe because we're not allowing MAP_FIXED, and invalid parameters cannot break
+        // Rust safety guarantees (things may change if we're mapping /dev/mem or some wacky file).
+        let addr = unsafe { libc::mmap(null_mut(), size, prot, flags, fd, offset as libc::off_t) };
+
+        if addr == libc::MAP_FAILED {
+            return Err(Error::Mmap(io::Error::last_os_error()));
+        }
+
         Ok(Self {
             addr: addr as *mut u8,
             size,
+            file_offset,
+            prot,
+            flags,
         })
     }
 
@@ -106,6 +138,49 @@ impl MmapRegion {
     /// used for passing this region to ioctls for setting guest memory.
     pub fn as_ptr(&self) -> *mut u8 {
         self.addr
+    }
+
+    /// Returns the size of this region.
+    pub fn size(&self) -> usize {
+        self.size
+    }
+
+    /// Returns information regarding the offset into the file backing this region (if any).
+    pub fn file_offset(&self) -> Option<&FileOffset> {
+        self.file_offset.as_ref()
+    }
+
+    /// Returns the value of the `prot` parameter passed to `mmap` when mapping this region.
+    pub fn prot(&self) -> i32 {
+        self.prot
+    }
+
+    /// Returns the value of the `flags` parameter passed to `mmap` when mapping this region.
+    pub fn flags(&self) -> i32 {
+        self.flags
+    }
+
+    /// Returns true if `self` and `other` map the same file descriptor, and the `(offset, size)`
+    /// pairs overlap. This is mostly a sanity check available for convenience, as different file
+    /// descriptors can alias the same file.
+    pub fn fds_overlap(&self, other: &MmapRegion) -> bool {
+        if let Some(f_off1) = self.file_offset() {
+            if let Some(f_off2) = other.file_offset() {
+                if f_off1.file().as_raw_fd() == f_off2.file().as_raw_fd() {
+                    let s1 = f_off1.start();
+                    let s2 = f_off2.start();
+                    let l1 = self.len() as u64;
+                    let l2 = other.len() as u64;
+
+                    if s1 < s2 {
+                        return s1 + l1 > s2;
+                    } else {
+                        return s2 + l2 > s1;
+                    }
+                }
+            }
+        }
+        false
     }
 }
 
@@ -156,13 +231,147 @@ impl Drop for MmapRegion {
 
 #[cfg(test)]
 mod tests {
-    use mmap_unix::MmapRegion;
-    use std::os::unix::io::FromRawFd;
+    use super::*;
+
+    use std::io::Write;
+    use std::slice;
+    use std::sync::Arc;
+
+    // Adding a helper method to extract the errno within an Error::Mmap(e), or return a
+    // distinctive value when the error is represented by another variant.
+    impl Error {
+        pub fn raw_os_error(&self) -> i32 {
+            return match self {
+                Error::Mmap(e) => e.raw_os_error().unwrap(),
+                _ => std::i32::MIN,
+            };
+        }
+    }
 
     #[test]
-    fn map_invalid_fd() {
-        let fd = unsafe { std::fs::File::from_raw_fd(-1) };
-        let e = MmapRegion::from_fd(&fd, 1024, 0).unwrap_err();
-        assert_eq!(e.raw_os_error(), Some(libc::EBADF));
+    fn test_mmap_region_new() {
+        assert!(MmapRegion::new(0).is_err());
+
+        let size = 4096;
+
+        let r = MmapRegion::new(4096).unwrap();
+        assert_eq!(r.size(), size);
+        assert!(r.file_offset().is_none());
+        assert_eq!(r.prot(), libc::PROT_READ | libc::PROT_WRITE);
+        assert_eq!(
+            r.flags(),
+            libc::MAP_ANONYMOUS | libc::MAP_NORESERVE | libc::MAP_PRIVATE
+        );
+    }
+
+    #[test]
+    fn test_mmap_region_from_file() {
+        let mut f = tempfile::tempfile().unwrap();
+        let offset: usize = 0;
+        let buf1 = [1u8, 2, 3, 4, 5];
+
+        f.write_all(buf1.as_ref()).unwrap();
+        let r = MmapRegion::from_file(FileOffset::new(f, offset as u64), buf1.len()).unwrap();
+
+        assert_eq!(r.size(), buf1.len() - offset);
+        assert_eq!(r.file_offset().unwrap().start(), offset as u64);
+        assert_eq!(r.prot(), libc::PROT_READ | libc::PROT_WRITE);
+        assert_eq!(r.flags(), libc::MAP_NORESERVE | libc::MAP_SHARED);
+
+        let buf2 = unsafe { slice::from_raw_parts(r.as_ptr(), buf1.len() - offset) };
+        assert_eq!(&buf1[offset..], buf2);
+    }
+
+    #[test]
+    fn test_mmap_region_build() {
+        let a = Arc::new(tempfile::tempfile().unwrap());
+
+        let prot = libc::PROT_READ | libc::PROT_WRITE;
+        let flags = libc::MAP_NORESERVE | libc::MAP_PRIVATE;
+        let offset = 4096;
+        let size = 1000;
+
+        // Offset + size will overflow.
+        let r = MmapRegion::build(
+            Some(FileOffset::from_arc(a.clone(), std::u64::MAX)),
+            size,
+            prot,
+            flags,
+        );
+        assert_eq!(format!("{:?}", r.unwrap_err()), "InvalidOffsetLength");
+
+        // Offset + size is greater than the size of the file (which is 0 at this point).
+        let r = MmapRegion::build(
+            Some(FileOffset::from_arc(a.clone(), offset)),
+            size,
+            prot,
+            flags,
+        );
+        assert_eq!(format!("{:?}", r.unwrap_err()), "MappingPastEof");
+
+        // MAP_FIXED was specified among the flags.
+        let r = MmapRegion::build(
+            Some(FileOffset::from_arc(a.clone(), offset)),
+            size,
+            prot,
+            flags | libc::MAP_FIXED,
+        );
+        assert_eq!(format!("{:?}", r.unwrap_err()), "MapFixed");
+
+        // Let's resize the file.
+        assert_eq!(unsafe { libc::ftruncate(a.as_raw_fd(), 1024 * 10) }, 0);
+
+        // The offset is not properly aligned.
+        let r = MmapRegion::build(
+            Some(FileOffset::from_arc(a.clone(), offset - 1)),
+            size,
+            prot,
+            flags,
+        );
+        assert_eq!(r.unwrap_err().raw_os_error(), libc::EINVAL);
+
+        // The build should be successful now.
+        let r = MmapRegion::build(
+            Some(FileOffset::from_arc(a.clone(), offset)),
+            size,
+            prot,
+            flags,
+        )
+        .unwrap();
+
+        assert_eq!(r.size(), size);
+        assert_eq!(r.file_offset().unwrap().start(), offset as u64);
+        assert_eq!(r.prot(), libc::PROT_READ | libc::PROT_WRITE);
+        assert_eq!(r.flags(), libc::MAP_NORESERVE | libc::MAP_PRIVATE);
+    }
+
+    #[test]
+    fn test_mmap_region_fds_overlap() {
+        let a = Arc::new(tempfile::tempfile().unwrap());
+        assert_eq!(unsafe { libc::ftruncate(a.as_raw_fd(), 1024 * 10) }, 0);
+
+        let r1 = MmapRegion::from_file(FileOffset::from_arc(a.clone(), 0), 4096).unwrap();
+        let r2 = MmapRegion::from_file(FileOffset::from_arc(a.clone(), 4096), 4096).unwrap();
+        assert!(!r1.fds_overlap(&r2));
+
+        let r1 = MmapRegion::from_file(FileOffset::from_arc(a.clone(), 0), 5000).unwrap();
+        assert!(r1.fds_overlap(&r2));
+
+        let r2 = MmapRegion::from_file(FileOffset::from_arc(a.clone(), 0), 1000).unwrap();
+        assert!(r1.fds_overlap(&r2));
+
+        // Different files, so there's not overlap.
+        let new_file = tempfile::tempfile().unwrap();
+        // Resize before mapping.
+        assert_eq!(
+            unsafe { libc::ftruncate(new_file.as_raw_fd(), 1024 * 10) },
+            0
+        );
+        let r2 = MmapRegion::from_file(FileOffset::new(new_file, 0), 5000).unwrap();
+        assert!(!r1.fds_overlap(&r2));
+
+        // R2 is not file backed, so no overlap.
+        let r2 = MmapRegion::new(5000).unwrap();
+        assert!(!r1.fds_overlap(&r2));
     }
 }


### PR DESCRIPTION
This PR is based on code from Sebastien's original proposal (#20) and the subsequent comments and conversations.

As per Paolo's suggestion, the offset is now represented as an `u64`. I didn't name the new struct `FileRange`, because it should've also kept a `length` field, and that information is already available via the `len()` method of the `GuestMemoryRegion`. Instead I've called it `FileOffset` (will rename on demand), and it only keeps the `Arc<File>` and `offset`.

The Linux code is clearly ahead of the Windows one right now, and some harmonization is in order. I've just created a Windows VM on my machine, but didn't get the chance to install Rust and test things yet. It would be good to know if ppl are ok with the proposed way of implementing this functionality on Linux, and then we can bring the Windows implementation up to date as well (and add some more tests to this PR).