### PR TITLE
migrate to rust edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Liu Jiang <gerry@linux.alibaba.com>"]
 repository = "https://github.com/rust-vmm/vm-memory"
 license = "Apache-2.0"
+edition = "2018"
 
 [features]
 default = []

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -224,9 +224,9 @@ data_init_type!(isize);
 
 #[cfg(test)]
 mod tests {
+    use crate::ByteValued;
     use std::fmt::Debug;
     use std::mem::{align_of, size_of};
-    use ByteValued;
 
     fn from_slice_alignment<T>()
     where

--- a/src/endian.rs
+++ b/src/endian.rs
@@ -32,7 +32,7 @@
 
 use std::mem::{align_of, size_of};
 
-use bytes::ByteValued;
+use crate::bytes::ByteValued;
 
 macro_rules! const_assert {
     ($condition:expr) => {

--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -34,9 +34,9 @@ use std::io::{self, Read, Write};
 use std::ops::{BitAnd, BitOr};
 use std::sync::Arc;
 
-use address::{Address, AddressValue};
-use bytes::Bytes;
-use volatile_memory;
+use crate::address::{Address, AddressValue};
+use crate::bytes::Bytes;
+use crate::volatile_memory;
 
 static MAX_ACCESS_CHUNK: usize = 4096;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,12 +17,6 @@
 
 #![deny(missing_docs)]
 
-extern crate libc;
-
-#[cfg(test)]
-#[macro_use]
-extern crate matches;
-
 #[macro_use]
 pub mod address;
 pub use address::{Address, AddressValue};

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -26,18 +26,18 @@ use std::ops::Deref;
 use std::result;
 use std::sync::Arc;
 
-use address::Address;
-use guest_memory::{
+use crate::address::Address;
+use crate::guest_memory::{
     self, FileOffset, GuestAddress, GuestMemory, GuestMemoryRegion, GuestUsize, MemoryRegionAddress,
 };
-use volatile_memory::VolatileMemory;
-use Bytes;
+use crate::volatile_memory::VolatileMemory;
+use crate::Bytes;
 
 #[cfg(unix)]
-pub use mmap_unix::{Error as MmapRegionError, MmapRegion};
+pub use crate::mmap_unix::{Error as MmapRegionError, MmapRegion};
 
 #[cfg(windows)]
-pub use mmap_windows::MmapRegion;
+pub use crate::mmap_windows::MmapRegion;
 #[cfg(windows)]
 pub use std::io::Error as MmapRegionError;
 

--- a/src/mmap_unix.rs
+++ b/src/mmap_unix.rs
@@ -27,9 +27,9 @@ use std::result;
 
 use libc;
 
-use guest_memory::FileOffset;
-use mmap::{check_file_offset, AsSlice};
-use volatile_memory::{self, compute_offset, VolatileMemory, VolatileSlice};
+use crate::guest_memory::FileOffset;
+use crate::mmap::{check_file_offset, AsSlice};
+use crate::volatile_memory::{self, compute_offset, VolatileMemory, VolatileSlice};
 
 /// Error conditions that may arise when creating a new `MmapRegion` object.
 #[derive(Debug)]

--- a/src/mmap_windows.rs
+++ b/src/mmap_windows.rs
@@ -13,18 +13,16 @@
 //! - [GuestMemoryMmap](struct.GuestMemoryMmap.html): provides methods to access a collection of
 //! GuestRegionMmap objects.
 
-use libc;
+use std;
 use std::io;
-use std::ptr::null_mut;
-
-use guest_memory::FileOffset;
-use mmap::AsSlice;
-use volatile_memory::{self, compute_offset, VolatileMemory, VolatileSlice};
+use std::os::windows::io::{AsRawHandle, RawHandle};
+use std::ptr::{null, null_mut};
 
 use libc::{c_void, size_t};
-use std;
-use std::os::windows::io::{AsRawHandle, RawHandle};
-use std::ptr::null;
+
+use crate::guest_memory::FileOffset;
+use crate::mmap::AsSlice;
+use crate::volatile_memory::{self, compute_offset, VolatileMemory, VolatileSlice};
 
 #[allow(non_snake_case)]
 #[link(name = "kernel32")]
@@ -229,8 +227,8 @@ impl Drop for MmapRegion {
 
 #[cfg(test)]
 mod tests {
-    use guest_memory::FileOffset;
-    use mmap_windows::{MmapRegion, INVALID_HANDLE_VALUE};
+    use crate::guest_memory::FileOffset;
+    use crate::mmap_windows::{MmapRegion, INVALID_HANDLE_VALUE};
     use std::os::windows::io::FromRawHandle;
 
     #[test]

--- a/src/volatile_memory.rs
+++ b/src/volatile_memory.rs
@@ -32,10 +32,10 @@ use std::result;
 use std::slice::{from_raw_parts, from_raw_parts_mut};
 use std::usize;
 
+use crate::{ByteValued, Bytes};
+
 // TODO: replace with TryFrom once we can assume 1.34.0.
 extern crate cast;
-
-use bytes::{ByteValued, Bytes};
 
 /// VolatileMemory related error codes
 #[allow(missing_docs)]
@@ -423,7 +423,7 @@ impl<'a> VolatileSlice<'a> {
     }
 }
 
-impl<'a> Bytes<usize> for VolatileSlice<'a> {
+impl Bytes<usize> for VolatileSlice<'_> {
     type E = Error;
 
     /// Writes a slice to the region at the specified address.
@@ -674,7 +674,7 @@ impl<'a> Bytes<usize> for VolatileSlice<'a> {
     }
 }
 
-impl<'a> VolatileMemory for VolatileSlice<'a> {
+impl VolatileMemory for VolatileSlice<'_> {
     fn len(&self) -> usize {
         self.size
     }
@@ -992,18 +992,17 @@ impl<'a> From<VolatileSlice<'a>> for VolatileArrayRef<'a, u8> {
 
 #[cfg(test)]
 mod tests {
-    extern crate tempfile;
-
     use super::*;
 
-    use self::tempfile::tempfile;
+    use std::fs::File;
+    use std::path::Path;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::thread::{sleep, spawn};
     use std::time::Duration;
 
-    use std::fs::File;
-    use std::path::Path;
+    use matches::assert_matches;
+    use tempfile::tempfile;
 
     #[derive(Clone)]
     struct VecMem {


### PR DESCRIPTION
Migrate to rust edition 2018 so we could make use new features.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>