### PR TITLE
[windows] Fix MmapRegion drop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ backend-mmap = []
 libc = ">=0.2.39"
 cast = ">=0"
 
+[target.'cfg(windows)'.dependencies.winapi]
+version = ">=0.3"
+features = ["errhandlingapi"]
+
 [dev-dependencies]
 matches = ">=0"
 tempfile = ">=3.0.2"


### PR DESCRIPTION
At the moment, we're not properly deallocating memory mapped regions.
The "VirtualFree" function will fail if the region size is specified
when using the "MEM_RELEASE" flag.

This change fixes it, also printing a message when VirtualFree fails,
which may help discovering memory leaks more easily.

Closes: #38