### PR TITLE
 mmap: Add a type parameter to the memory mapped regions 

### DIFF
--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -267,10 +267,16 @@ pub trait GuestMemory {
     /// ```
     /// # #[cfg(feature = "backend-mmap")]
     /// # fn test_map_fold() -> Result<(), ()> {
-    /// # use vm_memory::{GuestAddress, GuestMemory, GuestMemoryRegion, mmap::GuestMemoryMmap};
+    /// # use vm_memory::{
+    ///     GuestAddress, GuestMemory, GuestMemoryRegion, mmap::GuestMemoryMmap,
+    ///     RegionType
+    /// };
     ///     let start_addr1 = GuestAddress(0x0);
     ///     let start_addr2 = GuestAddress(0x400);
-    ///     let mem = GuestMemoryMmap::new(&vec![(start_addr1, 1024), (start_addr2, 2048)]).unwrap();
+    ///     let mem = GuestMemoryMmap::new(&vec![
+    ///         (start_addr1, 1024, RegionType::Ram),
+    ///         (start_addr2, 2048, RegionType::Ram)
+    ///         ]).unwrap();
     ///     let total_size = mem.map_and_fold(
     ///         0,
     ///         |(_, region)| region.len() / 1024,
@@ -493,7 +499,7 @@ impl<T: GuestMemory> Bytes<GuestAddress> for T {
 mod tests {
     use super::*;
     #[cfg(feature = "backend-mmap")]
-    use crate::{GuestAddress, GuestMemoryMmap};
+    use crate::{GuestAddress, GuestMemoryMmap, RegionType};
     #[cfg(feature = "backend-mmap")]
     use std::io::Cursor;
 
@@ -584,7 +590,11 @@ mod tests {
     fn checked_read_from() {
         let start_addr1 = GuestAddress(0x0);
         let start_addr2 = GuestAddress(0x40);
-        let mem = GuestMemoryMmap::new(&vec![(start_addr1, 64), (start_addr2, 64)]).unwrap();
+        let mem = GuestMemoryMmap::new(&vec![
+            (start_addr1, 64, RegionType::Ram),
+            (start_addr2, 64, RegionType::Ram),
+        ])
+        .unwrap();
         let image = make_image(0x80);
         let offset = GuestAddress(0x30);
         let count: usize = 0x20;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ mod mmap_windows;
 #[cfg(feature = "backend-mmap")]
 pub mod mmap;
 #[cfg(feature = "backend-mmap")]
-pub use mmap::{Error, GuestMemoryMmap, GuestRegionMmap, MmapRegion};
+pub use mmap::{Error, GuestMemoryMmap, GuestRegionMmap, MmapRegion, RegionType};
 
 pub mod volatile_memory;
 pub use volatile_memory::{


### PR DESCRIPTION
In order to let the caller identify regions based on the region type,
this patch introduces a new parameter as part of the region creation.

Fixes #34

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>