### PR TITLE
mmap: Allow an existing GuestMemoryMmap to be extended

### DIFF
--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 78.9,
+  "coverage_score": 78.2,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap"
 }

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -26,7 +26,6 @@ use std::fmt;
 use std::io::{Read, Write};
 use std::ops::Deref;
 use std::result;
-use std::sync::Arc;
 
 use crate::address::Address;
 use crate::guest_memory::{
@@ -363,9 +362,9 @@ impl GuestMemoryRegion for GuestRegionMmap {
 }
 
 /// Tracks memory regions allocated/mapped for the guest in the current process.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct GuestMemoryMmap {
-    regions: Arc<Vec<GuestRegionMmap>>,
+    regions: Vec<GuestRegionMmap>,
 }
 
 impl GuestMemoryMmap {
@@ -427,9 +426,7 @@ impl GuestMemoryMmap {
             }
         }
 
-        Ok(Self {
-            regions: Arc::new(regions),
-        })
+        Ok(Self { regions })
     }
 
     /// Convert an absolute address into an address space (GuestMemory)
@@ -1000,8 +997,8 @@ mod tests {
             .map(|x| (x.0, x.1))
             .eq(iterated_regions.iter().map(|x| *x)));
 
-        assert_eq!(gm.clone().regions[0].guest_base, regions[0].0);
-        assert_eq!(gm.clone().regions[1].guest_base, regions[1].0);
+        assert_eq!(gm.regions[0].guest_base, regions[0].0);
+        assert_eq!(gm.regions[1].guest_base, regions[1].0);
     }
 
     #[test]


### PR DESCRIPTION
The public API of vm-memory is pretty limited regarding the actions
that can be performed on a GuestMemoryMmap. The only allowed action
is to create a new instance of a GuestMemoryMmap based on a list of
memory ranges, but there are use cases where we need to extend an
existing instance by appending more memory regions to the existing
ones.

This PR creates a new public function that can be used from any
caller in order to add a new memory region to an existing guest memory.
Note that rework of the existing code was necessary to apply proper
factorization.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>