### PR TITLE
A bunch of small changes, plus removing try_access

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ backend-mmap = []
 
 [dependencies]
 libc = ">=0.2.39"
-cast = ">=0"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = ">=0.3"

--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 84.5,
+  "coverage_score": 84.3,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap"
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -247,6 +247,7 @@ mod tests {
         );
         if expected_overflow {
             assert!(MockAddress(a).checked_add(b).is_none());
+            #[cfg(debug_assertions)]
             assert!(std::panic::catch_unwind(|| MockAddress(a).unchecked_add(b)).is_err());
         } else {
             assert_eq!(
@@ -280,6 +281,7 @@ mod tests {
         if expected_overflow {
             assert!(MockAddress(a).checked_sub(b).is_none());
             assert!(MockAddress(a).checked_offset_from(MockAddress(b)).is_none());
+            #[cfg(debug_assertions)]
             assert!(std::panic::catch_unwind(|| MockAddress(a).unchecked_sub(b)).is_err());
         } else {
             assert_eq!(

--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -582,16 +582,15 @@ impl<T: GuestMemory> Bytes<GuestAddress> for T {
                 // This is safe cause `start` and `len` are within the `region`.
                 let start = caddr.raw_value() as usize;
                 let end = start + len;
-                src.read_exact(&mut dst[start..end])
-                    .map_err(Error::IOError)?;
-                Ok(len)
+                let bytes_read = src.read(&mut dst[start..end]).map_err(Error::IOError)?;
+                Ok(bytes_read)
             } else {
                 let len = std::cmp::min(len, MAX_ACCESS_CHUNK);
                 let mut buf = vec![0u8; len].into_boxed_slice();
                 let bytes_read = src.read(&mut buf[..]).map_err(Error::IOError)?;
                 let bytes_written = region.write(&buf[0..bytes_read], caddr)?;
                 assert_eq!(bytes_written, bytes_read);
-                Ok(len)
+                Ok(bytes_read)
             }
         })
     }

--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -216,7 +216,9 @@ pub trait GuestMemoryRegion: Bytes<MemoryRegionAddress, E = Error> {
     }
 
     /// Returns information regarding the file and offset backing this memory region.
-    fn file_offset(&self) -> Option<&FileOffset>;
+    fn file_offset(&self) -> Option<&FileOffset> {
+        None
+    }
 
     /// Returns a slice corresponding to the data in the region.
     ///

--- a/src/volatile_memory.rs
+++ b/src/volatile_memory.rs
@@ -489,7 +489,7 @@ impl Bytes<usize> for VolatileSlice<'_> {
             // volatile.  Writing to it with what compiles down to a memcpy
             // won't hurt anything as long as we get the bounds checks right.
             let mut slice: &mut [u8] = &mut self.as_mut_slice()[addr..];
-            Ok(slice.write(buf).map_err(Error::IOError)?)
+            slice.write(buf).map_err(Error::IOError)
         }
     }
 
@@ -515,7 +515,7 @@ impl Bytes<usize> for VolatileSlice<'_> {
             // volatile.  Writing to it with what compiles down to a memcpy
             // won't hurt anything as long as we get the bounds checks right.
             let slice: &[u8] = &self.as_slice()[addr..];
-            Ok(buf.write(slice).map_err(Error::IOError)?)
+            buf.write(slice).map_err(Error::IOError)
         }
     }
 

--- a/src/volatile_memory.rs
+++ b/src/volatile_memory.rs
@@ -467,7 +467,7 @@ impl Bytes<usize> for VolatileSlice<'_> {
     type E = Error;
 
     /// # Examples
-    /// * Write a slice at offset 256.
+    /// * Write a slice of size 5 at offset 1020 of a 1024-byte VolatileSlice.
     ///
     /// ```
     /// #   use vm_memory::{Bytes, VolatileMemory};
@@ -492,7 +492,7 @@ impl Bytes<usize> for VolatileSlice<'_> {
     }
 
     /// # Examples
-    /// * Read a slice of size 16 at offset 256.
+    /// * Read a slice of size 16 at offset 1010 of a 1024-byte VolatileSlice.
     ///
     /// ```
     /// #   use vm_memory::{Bytes, VolatileMemory};
@@ -526,8 +526,8 @@ impl Bytes<usize> for VolatileSlice<'_> {
     /// #   let mut mem_ref = &mut mem[..];
     /// #   let vslice = mem_ref.as_volatile_slice();
     ///     let res = vslice.write_slice(&[1,2,3,4,5], 256);
-    ///     assert!(res.is_ok());
-    ///     assert_eq!(res.unwrap(), ());
+    /// #   assert!(res.is_ok());
+    /// #   assert_eq!(res.unwrap(), ());
     /// ```
     fn write_slice(&self, buf: &[u8], addr: usize) -> Result<()> {
         let len = self.write(buf, addr)?;
@@ -550,8 +550,8 @@ impl Bytes<usize> for VolatileSlice<'_> {
     /// #   let vslice = mem_ref.as_volatile_slice();
     ///     let buf = &mut [0u8; 16];
     ///     let res = vslice.read_slice(buf, 256);
-    ///     assert!(res.is_ok());
-    ///     assert_eq!(res.unwrap(), ());
+    /// #   assert!(res.is_ok());
+    /// #   assert_eq!(res.unwrap(), ());
     /// ```
     fn read_slice(&self, buf: &mut [u8], addr: usize) -> Result<()> {
         let len = self.read(buf, addr)?;


### PR DESCRIPTION
Hi all, this is a bunch of small changes, mostly cosmetic, that I had lying around. Most of the patches are small enough that it is probably unnecessary to create many pull requests for them.

The biggest is probably removing `try_access()`, in favor of an iterator-like object. Whether the code is nicer is in the eye of the beholder, I guess. I like the code of the users more, because it avoids a closure, but the code of the iterator is quite ugly as it often happens.