### PR TITLE
mmap: Protect each GuestMemoryMmap region with its own Arc

### DIFF
--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 78.9,
+  "coverage_score": 79.0,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap"
 }


### PR DESCRIPTION
The goal here is to ensure GuestMemoryMmap stays immutable, but that a
consuming layer on top of it could still use it to extend the effective
guest address space.

By moving the existing Arc from the outside of the Vec to the inside, we
make sure a GuestRegionMmap never gets released by mistake (which would
cause an unmap of the actual region), and we let the possibility for
each of these regions to be properly cloned into the new extended
instance of GuestMemoryMmap.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>