### PR TITLE
mmap: implement Binary search in find_region()

### DIFF
--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -462,12 +462,13 @@ impl GuestMemory for GuestMemoryMmap {
     }
 
     fn find_region(&self, addr: GuestAddress) -> Option<&GuestRegionMmap> {
-        for region in self.regions.iter() {
-            if addr >= region.start_addr() && addr <= region.end_addr() {
-                return Some(region);
-            }
-        }
-        None
+        let index = match self.regions.binary_search_by_key(&addr, |x| x.start_addr()) {
+            Ok(x) => Some(x),
+            // Within the closest region with starting address < addr
+            Err(x) if (x > 0 && addr <= self.regions[x - 1].end_addr()) => Some(x - 1),
+            _ => None,
+        };
+        index.map(|x| self.regions[x].as_ref())
     }
 
     fn with_regions<F, E>(&self, cb: F) -> result::Result<(), E>


### PR DESCRIPTION
This patch uses binary search to search in regions, as mentioned in issue #41;
the UnsortedMemoryRegions error already makes sure that memory regions are
sorted when a new GuestMemoryMmap is created.

Signed-off-by: Emin Ghuliev <drmint80@gmail.com>
Signed-off-by: Paolo Bonzini <pbonzini@redhat.com>