### PR TITLE
mmap: Introduce new constructor for extending GuestMemoryMmap

### DIFF
--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 79.0,
+  "coverage_score": 79.1,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap"
 }


### PR DESCRIPTION
In case the consumer of the API tries to extend an existing
GuestMemoryMmap with some new regions, it will need a special
constructor to accept a Vec<Arc<GuestRegionMmap>> instead of
Vec<GuestRegionMmap>. The existing regions coming from the existing
GuestMemoryMmap will come as a list of Arc<GuestRegionMmap>, which
is why the existing constructor cannot be reused in this case.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>