### PR TITLE
Rename guest memory `end_addr` to `last addr`

### DIFF
--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -164,7 +164,7 @@ pub trait GuestMemoryRegion: Bytes<MemoryRegionAddress, E = Error> {
     fn start_addr(&self) -> GuestAddress;
 
     /// Get maximum (inclusive) address managed by the region.
-    fn end_addr(&self) -> GuestAddress {
+    fn last_addr(&self) -> GuestAddress {
         // unchecked_add is safe as the region bounds were checked when it was created.
         self.start_addr().unchecked_add(self.len() - 1)
     }
@@ -302,10 +302,10 @@ pub trait GuestMemory {
         G: Fn(T, T) -> T;
 
     /// Get maximum (inclusive) address managed by the region.
-    fn end_addr(&self) -> GuestAddress {
+    fn last_addr(&self) -> GuestAddress {
         self.map_and_fold(
             GuestAddress(0),
-            |(_, region)| region.end_addr(),
+            |(_, region)| region.last_addr(),
             std::cmp::max,
         )
     }

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -438,7 +438,7 @@ impl GuestMemoryMmap {
                 return Err(Error::UnsortedMemoryRegions);
             }
 
-            if prev.end_addr() >= next.start_addr() {
+            if prev.last_addr() >= next.start_addr() {
                 return Err(Error::MemoryRegionOverlap);
             }
         }
@@ -458,7 +458,7 @@ impl GuestMemory for GuestMemoryMmap {
         let index = match self.regions.binary_search_by_key(&addr, |x| x.start_addr()) {
             Ok(x) => Some(x),
             // Within the closest region with starting address < addr
-            Err(x) if (x > 0 && addr <= self.regions[x - 1].end_addr()) => Some(x - 1),
+            Err(x) if (x > 0 && addr <= self.regions[x - 1].last_addr()) => Some(x - 1),
             _ => None,
         };
         index.map(|x| self.regions[x].as_ref())
@@ -526,11 +526,11 @@ mod tests {
         assert_eq!(guest_mem.num_regions(), expected_regions_summary.len());
         let maybe_last_mem_reg = expected_regions_summary.last();
         if let Some((region_addr, region_size)) = maybe_last_mem_reg {
-            let mut end_addr = region_addr.unchecked_add(*region_size as u64);
-            if end_addr.raw_value() != 0 {
-                end_addr = end_addr.unchecked_sub(1);
+            let mut last_addr = region_addr.unchecked_add(*region_size as u64);
+            if last_addr.raw_value() != 0 {
+                last_addr = last_addr.unchecked_sub(1);
             }
-            assert_eq!(guest_mem.end_addr(), end_addr);
+            assert_eq!(guest_mem.last_addr(), last_addr);
         }
         for ((region_addr, region_size), mmap) in expected_regions_summary
             .iter()


### PR DESCRIPTION
`end_addr` is a method implemented both in `GuestMemoryRegion` and `GuestMemory`, which returns the maximum address contained by the memory region or guest memory respectively.

I suggest renaming `end_addr` to `last_addr`, and thus disambiguate what the method returns. 
In my opinion, the ambiguity comes from the vague `end` term, which is a noun, and does tangentially suggests that the address is at the end of the region/guest memory, but it is not clear enough that it refers to an included address.

I think a better word would be `last`, which is an adjective, and it does a better job in describing what kind of `addr` the method returns, namely the last address of a region/guest memory.

Signed-off-by: Iulian Barbu <iul@amazon.com>