### PR TITLE
Export FileOffset at the top level namespace

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,8 @@ pub use endian::{Be16, Be32, Be64, BeSize, Le16, Le32, Le64, LeSize};
 
 pub mod guest_memory;
 pub use guest_memory::{
-    Error as GuestMemoryError, GuestAddress, GuestMemory, GuestMemoryRegion, GuestUsize,
-    MemoryRegionAddress, Result as GuestMemoryResult,
+    Error as GuestMemoryError, FileOffset, GuestAddress, GuestMemory, GuestMemoryRegion,
+    GuestUsize, MemoryRegionAddress, Result as GuestMemoryResult,
 };
 
 #[cfg(all(feature = "backend-mmap", unix))]

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -835,9 +835,9 @@ mod tests {
 
     #[test]
     fn test_to_region_addr() {
-        let f1 = TempFile::new().unwrap().into_file();;
+        let f1 = TempFile::new().unwrap().into_file();
         f1.set_len(0x400).unwrap();
-        let f2 = TempFile::new().unwrap().into_file();;
+        let f2 = TempFile::new().unwrap().into_file();
         f2.set_len(0x400).unwrap();
 
         let start_addr1 = GuestAddress(0x0);


### PR DESCRIPTION
The struct FileOffset is used by the GuestMemoryRegion trait, so export
FileOffset at the top level namespace, to keep consistence with
GuestMemoryRegion.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>