### PR TITLE
Mark GuestMemory as Send + Sync

### DIFF
--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -249,7 +249,7 @@ pub trait GuestMemoryRegion: Bytes<MemoryRegionAddress, E = Error> {
 /// - handle cases where an access request spanning two or more GuestMemoryRegion objects.
 ///
 /// Note: the regions inside a [`GuestMemory`](trait.GuestMemory.html) object must not overlap.
-pub trait GuestMemory {
+pub trait GuestMemory: Send + Sync {
     /// Type of objects hosted by the address space.
     type R: GuestMemoryRegion;
 


### PR DESCRIPTION
Instances of GuestMemory will almost be accessed from multiple vCPU
threads and IO threads, so it should be Send + Sync. On the other hand,
it helps to simplify the conversion from
struct VirtioDeviceA {
	mem: GuestMemoryMmap,
}
to
struct VirtioDeviceA<M: GuestMemory> {
	mem: M,
}

Otherwise we need to add too much Send + Sync markers.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>