### PR TITLE
improve fds_overlap()

### DIFF
--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 84.5,
+  "coverage_score": 84.2,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap"
 }


### PR DESCRIPTION
- compare dev and inode instead of fd, in order to ensure uniqueness
- use less comparisons