### PR TITLE
fixed the crate manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "vm-memory"
 version = "0.1.0"
+description = "Safe abstractions for accessing the VM physical memory"
+keywords = ["memory", "virtual machine"]
 authors = ["Liu Jiang <gerry@linux.alibaba.com>"]
 repository = "https://github.com/rust-vmm/vm-memory"
 license = "Apache-2.0 OR BSD-3-Clause"


### PR DESCRIPTION
The crate description is a required field of the manifest. This is
needed for publishing the crates on crates.io.

Added keywords as well to make this crate easy to discover.