### PR TITLE
crates.io doesn't accept keywords with spaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vm-memory"
 version = "0.1.0"
 description = "Safe abstractions for accessing the VM physical memory"
-keywords = ["memory", "virtual machine"]
+keywords = ["memory"]
 authors = ["Liu Jiang <gerry@linux.alibaba.com>"]
 repository = "https://github.com/rust-vmm/vm-memory"
 license = "Apache-2.0 OR BSD-3-Clause"


### PR DESCRIPTION
I HATE CRATES.IO!