### PR TITLE
Make result of GuestAddressSpace::memory() cloneable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ backend-atomic = ["arc-swap"]
 
 [dependencies]
 libc = ">=0.2.39"
-arc-swap = { version = ">=0.4.4", optional = true }
+arc-swap = { version = ">=0.4.5", optional = true }
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = ">=0.3"

--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 85.6,
+  "coverage_score": 85.7,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap,backend-atomic"
 }

--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -356,7 +356,7 @@ pub trait GuestAddressSpace {
     type M: GuestMemory;
 
     /// A type that provides access to the memory.
-    type T: Deref<Target = Self::M>;
+    type T: Clone + Deref<Target = Self::M>;
 
     /// Return an object (e.g. a reference or guard) that can be used
     /// to access memory through this address space.  The object provides


### PR DESCRIPTION
I needed this in order to update vm-virtio for GuestAddressSpace support. Unfortunately this requires support in the arc-swap crate too.