### PR TITLE
Update CI and enable coverage test on Aarch64

### DIFF
--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 84.8,
+  "coverage_score": 82.4,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap,backend-atomic"
 }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,0 +1,5 @@
+{
+  "coverage_score": 84.7,
+  "exclude_path": "mmap_windows.rs",
+  "crate_features": "backend-mmap,backend-atomic"
+}


### PR DESCRIPTION
Although vm-memory is not architecture specific, it is better to align
with the latest CI and have ARM coverage tested.

Signed-off-by: Michael Zhao <michael.zhao@arm.com>