### PR TITLE
vm-memory version v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
-[v0.1.0]
+# [v0.2.0]
 
-# Added
+## Added
+
+- [[#76]](https://github.com/rust-vmm/vm-memory/issues/76): Added `get_slice` and
+  `as_volatile_slice` to `GuestMemoryRegion`.
+- [[#82]](https://github.com/rust-vmm/vm-memory/issues/82): Added `Clone` bound
+  for `GuestAddressSpace::T`, the return value of `GuestAddressSpace::memory()`.
+- [[#88]](https://github.com/rust-vmm/vm-memory/issues/88): Added `as_bytes` for
+  `ByteValued` which can be used for reading into POD structures from
+  raw bytes.
+
+# [v0.1.0]
+
+## Added
 
 - Added traits for working with VM memory.
 - Added a mmap based implemention for the Guest Memory.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vm-memory"
-version = "0.1.0"
+version = "0.2.0"
 description = "Safe abstractions for accessing the VM physical memory"
 keywords = ["memory"]
 authors = ["Liu Jiang <gerry@linux.alibaba.com>"]


### PR DESCRIPTION
This PR is needed for publishing a new version of vm-memory on crates.io.

Changes from the previous release include:
- fixing the manifest so that crates.io doesn't show a blank page for the vm-memory crate
- as_bytes for BytedValue which unblocks the work on: https://github.com/rust-vmm/linux-loader/pull/26
- `get_slice` and `as_volatile_slice` to GuestMemoryRegion