### PR TITLE
handle ErrorKind::Interrupted when doing file IOs

### DIFF
--- a/coverage_config.json
+++ b/coverage_config.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 85.7,
+  "coverage_score": 84.9,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap,backend-atomic"
 }


### PR DESCRIPTION
Fix #90 

Quote from rust doc for Read::read():
If this function encounters any form of I/O or other error, an error
variant will be returned. If an error is returned then it must be
guaranteed that no bytes were read.

An error of the [`ErrorKind::Interrupted`] kind is non-fatal and the
read operation should be retried if there is nothing else to do.

So we should silently ignore [`ErrorKind::Interrupted`] and retry,
otherwise it will false alarms/wrong results.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>