### PR TITLE
Add explicit atomic (and aligned) operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Changelog 
+
 ## [Unreleased]
 
 ### Fixed
+
 - [[#106]](https://github.com/rust-vmm/vm-memory/issues/106): Asserts trigger
   on zero-length access.  
 
 ### Added
+
+- [[#104]](https://github.com/rust-vmm/vm-memory/pull/104): Add explicit atomic
+  and aligned operations to the `Bytes` interface.
 - [[#109]](https://github.com/rust-vmm/vm-memory/pull/109): Added `build_raw` to
   `MmapRegion` which can be used to operate on externally created mappings.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ autobenches = false
 
 [features]
 default = []
-integer-atomics = []
 backend-mmap = []
 backend-atomic = ["arc-swap"]
 

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 85.1,
+  "coverage_score": 84.8,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap,backend-atomic"
 }

--- a/src/align.rs
+++ b/src/align.rs
@@ -1,0 +1,113 @@
+//! Provides abstractions (often effectively zero-cost) for modeling the alignment
+//! of addresses by leveraging the type system.
+
+use std::convert::TryFrom;
+use std::marker::PhantomData;
+use std::mem::align_of;
+use std::result;
+
+use crate::Address;
+
+/// Errors related to operations which involve aligned addresses.
+#[derive(Debug, PartialEq)]
+pub enum AlignmentError {
+    /// Misalignment was detected during a conversion.
+    Misaligned,
+    /// An overflow occurred while computing address values.
+    Overflow,
+}
+
+// Check whether `addr` is aligned with respect to `T`.
+fn check_addr_aligned<Addr: Address, T>(addr: Addr) -> result::Result<(), AlignmentError> {
+    // The value returned from `align_of` should fit within an `u8`
+    // for the foreseeable future.
+    let align = u8::try_from(align_of::<T>()).expect("Unexpected align_of value.");
+    let aligned_addr = addr
+        .checked_align_up(Addr::V::from(align))
+        .ok_or(AlignmentError::Overflow)?;
+    if addr == aligned_addr {
+        Ok(())
+    } else {
+        Err(AlignmentError::Misaligned)
+    }
+}
+
+/// An address that's aligned with respect to `T`.
+#[derive(Clone, Copy)]
+pub struct Aligned<Addr, T> {
+    addr: Addr,
+    phantom: PhantomData<*const T>,
+}
+
+impl<Addr, T> Aligned<Addr, T> {
+    /// Instantiate a new `Aligned` value without checking the alignment.
+    ///
+    /// # Safety
+    ///
+    /// The value of `addr` must be aligned with respect to `T`.
+    pub unsafe fn new(addr: Addr) -> Self {
+        Aligned {
+            addr,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Return the inner address value.
+    pub fn into(self) -> Addr {
+        self.addr
+    }
+
+    /// Convert `self` into an `Aligned` value with the specified alignment without
+    /// performing any checks.
+    ///
+    /// # Safety
+    ///
+    /// The inner address value must be aligned with respect to `U`.
+    pub unsafe fn reinterpret<U>(self) -> Aligned<Addr, U> {
+        Aligned {
+            addr: self.addr,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<Addr: Address, T> Aligned<Addr, T> {
+    /// Attempt to create an `Aligned` value based on `addr`.
+    pub fn from_addr(addr: Addr) -> result::Result<Self, AlignmentError> {
+        check_addr_aligned::<Addr, T>(addr)?;
+        // Safe because we checked the alignment.
+        Ok(unsafe { Self::new(addr) })
+    }
+
+    /// Attempt to convert `self` into an `Aligned` value with the specified alignment.
+    pub fn cast<U>(self) -> result::Result<Aligned<Addr, U>, AlignmentError> {
+        // Fast (compile time) conversion path.
+        if align_of::<T>() >= align_of::<U>() {
+            // Safe because the above inequality holds.
+            Ok(unsafe { self.reinterpret::<U>() })
+        } else {
+            Aligned::from_addr(self.addr)
+        }
+    }
+
+    /// Attempt to obtain an `Aligned<Addr, U>` after offsetting the current address by `value`.
+    pub fn offset<U>(self, value: Addr::V) -> result::Result<Aligned<Addr, U>, AlignmentError> {
+        let addr = self
+            .addr
+            .checked_add(value)
+            .ok_or(AlignmentError::Overflow)?;
+
+        // Fast path.
+        if align_of::<T>() >= align_of::<U>() {
+            // We only need to check if the offset value is aligned here w.r.t. `U`, because we
+            // know the  base is aligned based on the condition above. This check can be optimized
+            // away in certain conditions (i.e. when `value` is known at compile time).
+            check_addr_aligned::<Addr, U>(Addr::new(value))?;
+
+            // Safe because the above checks/conditions ensure `addr` is properly aligned.
+            Ok(unsafe { Aligned::new(addr) })
+        } else {
+            Aligned::from_addr(addr)
+        }
+    }
+}

--- a/src/align.rs
+++ b/src/align.rs
@@ -33,11 +33,23 @@ fn check_addr_aligned<Addr: Address, T>(addr: Addr) -> result::Result<(), Alignm
 }
 
 /// An address that's aligned with respect to `T`.
-#[derive(Clone, Copy)]
 pub struct Aligned<Addr, T> {
     addr: Addr,
     phantom: PhantomData<*const T>,
 }
+
+// Implementing `Clone` and `Copy` manually because deriving them did not work well
+// (most likely because `T` does not need to be `Clone`/`Copy` here).
+impl<Addr: Clone, T> Clone for Aligned<Addr, T> {
+    fn clone(&self) -> Self {
+        Self {
+            addr: self.addr.clone(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<Addr: Copy, T> Copy for Aligned<Addr, T> {}
 
 impl<Addr, T> Aligned<Addr, T> {
     /// Instantiate a new `Aligned` value without checking the alignment.

--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -39,9 +39,11 @@ use std::fs::File;
 use std::io::{self, Read, Write};
 use std::ops::{BitAnd, BitOr, Deref};
 use std::rc::Rc;
+use std::result;
 use std::sync::Arc;
 
 use crate::address::{Address, AddressValue};
+use crate::align::{Aligned, AlignmentError};
 use crate::bytes::Bytes;
 use crate::volatile_memory;
 
@@ -119,10 +121,32 @@ impl Display for Error {
 pub struct GuestAddress(pub u64);
 impl_address_ops!(GuestAddress, u64);
 
+/// Wraps a `GuestAddress` that's known to be aligned with respect to `T`.
+pub type AlignedGuestAddress<T> = Aligned<GuestAddress, T>;
+
+impl<T> std::convert::TryFrom<GuestAddress> for AlignedGuestAddress<T> {
+    type Error = AlignmentError;
+
+    fn try_from(other: GuestAddress) -> result::Result<Self, Self::Error> {
+        Self::from_addr(other)
+    }
+}
+
 /// Represents an offset inside a region.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct MemoryRegionAddress(pub u64);
 impl_address_ops!(MemoryRegionAddress, u64);
+
+/// Wraps a `MemoryRegionAddress` that's known to be aligned with respect to `T`.
+pub type AlignedMemoryRegionAddress<T> = Aligned<MemoryRegionAddress, T>;
+
+impl<T> std::convert::TryFrom<MemoryRegionAddress> for AlignedMemoryRegionAddress<T> {
+    type Error = AlignmentError;
+
+    fn try_from(other: MemoryRegionAddress) -> result::Result<Self, Self::Error> {
+        Self::from_addr(other)
+    }
+}
 
 /// Type of the raw value stored in a `GuestAddress` object.
 pub type GuestUsize = <GuestAddress as AddressValue>::V;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub mod align;
 pub use align::{Aligned, AlignmentError};
 
 pub mod bytes;
-pub use bytes::{AtomicInteger, ByteValued, Bytes};
+pub use bytes::{AtomicAccess, AtomicInteger, ByteValued, Bytes};
 
 pub mod endian;
 pub use endian::{Be16, Be32, Be64, BeSize, Le16, Le32, Le64, LeSize};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,9 @@
 pub mod address;
 pub use address::{Address, AddressValue};
 
+pub mod align;
+pub use align::{Aligned, AlignmentError};
+
 pub mod bytes;
 pub use bytes::{ByteValued, Bytes};
 
@@ -31,8 +34,9 @@ pub use endian::{Be16, Be32, Be64, BeSize, Le16, Le32, Le64, LeSize};
 
 pub mod guest_memory;
 pub use guest_memory::{
-    Error as GuestMemoryError, FileOffset, GuestAddress, GuestAddressSpace, GuestMemory,
-    GuestMemoryRegion, GuestUsize, MemoryRegionAddress, Result as GuestMemoryResult,
+    AlignedGuestAddress, AlignedMemoryRegionAddress, Error as GuestMemoryError, FileOffset,
+    GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryRegion, GuestUsize,
+    MemoryRegionAddress, Result as GuestMemoryResult,
 };
 
 #[cfg(all(feature = "backend-mmap", unix))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub mod align;
 pub use align::{Aligned, AlignmentError};
 
 pub mod bytes;
-pub use bytes::{ByteValued, Bytes};
+pub use bytes::{AtomicInteger, ByteValued, Bytes};
 
 pub mod endian;
 pub use endian::{Be16, Be32, Be64, BeSize, Le16, Le32, Le64, LeSize};
@@ -57,6 +57,6 @@ pub use atomic::{GuestMemoryAtomic, GuestMemoryLoadGuard};
 
 pub mod volatile_memory;
 pub use volatile_memory::{
-    AtomicInteger, Error as VolatileMemoryError, Result as VolatileMemoryResult, VolatileArrayRef,
-    VolatileMemory, VolatileRef, VolatileSlice,
+    Error as VolatileMemoryError, Result as VolatileMemoryResult, VolatileArrayRef, VolatileMemory,
+    VolatileRef, VolatileSlice,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,6 @@ pub use atomic::{GuestMemoryAtomic, GuestMemoryLoadGuard};
 
 pub mod volatile_memory;
 pub use volatile_memory::{
-    AtomicValued, Error as VolatileMemoryError, Result as VolatileMemoryResult, VolatileArrayRef,
+    AtomicInteger, Error as VolatileMemoryError, Result as VolatileMemoryResult, VolatileArrayRef,
     VolatileMemory, VolatileRef, VolatileSlice,
 };

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -1431,4 +1431,22 @@ mod tests {
         assert!(guest_mem.get_slice(GuestAddress(0x600), 0x100).is_err());
         assert!(guest_mem.get_slice(GuestAddress(0xc00), 0x100).is_err());
     }
+
+    #[test]
+    fn test_region_check_ptr() {
+        let region_size = 0x1000;
+        let region =
+            GuestRegionMmap::new(MmapRegion::new(region_size).unwrap(), GuestAddress(0)).unwrap();
+
+        for addr_value in [0, 0x123, region_size as u64 - 8].iter().copied() {
+            let ptr = region
+                .check_ptr::<u64>(MemoryRegionAddress(addr_value))
+                .unwrap();
+            assert_eq!(ptr as u64, region.mapping.as_ptr() as u64 + addr_value);
+        }
+
+        assert!(region
+            .check_ptr::<u64>(MemoryRegionAddress(region_size as u64 - 4))
+            .is_err());
+    }
 }

--- a/src/volatile_memory.rs
+++ b/src/volatile_memory.rs
@@ -592,6 +592,13 @@ impl Bytes<usize> for VolatileSlice<'_> {
         self.get_atomic_ref(addr.into())
     }
 
+    // TODO: We're currently using the default `Bytes` implementations for `write_aligned` and
+    // `read_aligned`. That's fine as long as there are no additional semantics associated with
+    // the two methods beyond having a parameter whose value is always aligned with respect to
+    // `T`. If that ever changes, we have to be wary of the implications for `VolatileSlice`
+    // objects which do not start at aligned addresses themselves, and thus do not properly
+    // support `Aligned<A, T>` semantics.
+
     /// # Examples
     ///
     /// * Read bytes from /dev/urandom

--- a/src/volatile_memory.rs
+++ b/src/volatile_memory.rs
@@ -1606,4 +1606,16 @@ mod tests {
         assert_eq!(super::alignment(a + 12), 4);
         assert_eq!(super::alignment(a + 8), 8);
     }
+
+    #[test]
+    fn test_atomic_ref() {
+        use crate::bytes::tests::test_atomic_access;
+
+        let vec_mem = VecMem::new(0x1000);
+        let volatile_slice = vec_mem.as_volatile_slice();
+        let addr = 0;
+        let bad_offset = 0x1_0000;
+
+        test_atomic_access(&volatile_slice, addr, bad_offset);
+    }
 }


### PR DESCRIPTION
Related to #102

Hi,

This PR adds four new methods (`read_atomic`, `write_atomic`, `read_aligned`, and `write_aligned`) to the `GuestMemory` and `GuestMemoryRegion` interfaces. Here are some details:

- The proposal is mainly about adding `read_atomic` and `write_atomic` as part of the `GuestMemory` interface in order to provide a more straightforward (and always available) mechanism for performing atomic accesses with explicit semantics.

- The `Aligned<Addr, T>` abstraction appears interesting and useful to represent additional alignment information and/or requirements about an address. It needs some more methods to improve the ergonomics of casting + offsetting, together with examples, but for the time being I am really curious if others also think this is worth pursuing.

- For now, the new methods are added directly to `GuestMemory` and `GuestMemoryRegion` (as opposed to being part of the `Bytes` interface) because `Bytes` provides no guarantees about the alignment of the container (whereas both `GuestMemory` and `GuestMemoryRegion` are expected to be aligned to page boundaries -- maybe we should mention this explicitly btw). There are a couple of ways to reconcile the interfaces going forward, but I think what matters for now is to have a well-defined and straightforward way of performing atomic accesses based on a generic `M: GuestMemory` object.

- I've also ran a couple of synthetic tests, and the improvement for atomic reads/writes seems quite promising (i.e. > 2x). I'll try to do some more after I manage to get a better setup going.