### PR TITLE
Relax assertions for zero-length accesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
-# [v0.2.0]
+# Changelog 
+## [Unreleased]
 
-## Added
+### Fixed
+- [[#106]](https://github.com/rust-vmm/vm-memory/issues/106): Asserts trigger
+  on zero-length access.  
+
+## [v0.2.0]
+
+### Added
 
 - [[#76]](https://github.com/rust-vmm/vm-memory/issues/76): Added `get_slice` and
   `as_volatile_slice` to `GuestMemoryRegion`.
@@ -10,9 +17,9 @@
   `ByteValued` which can be used for reading into POD structures from
   raw bytes.
 
-# [v0.1.0]
+## [v0.1.0]
 
-## Added
+### Added
 
 - Added traits for working with VM memory.
 - Added a mmap based implemention for the Guest Memory.


### PR DESCRIPTION
Related to #106 

Relax the assertions from `write_to` and `read_from` to allow equality between `offset` and `count`, which no longer leads to panics when zero-length accesses happen. This is preferred versus adding an explicit check for `count` or `len == 0` somewhere, because we don't end up with an additional branch on the regular path. Also tweaked the `try_access` logic a bit, to return `Ok(0)` when `total == 0` but we found a valid region associated with the current address (which indicates a zero-length access). Will create similar PRs for `0.1.x` and `0.2.x`.