### PR TITLE
Relax assertions for zero-length accesses (for v0.1.2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vm-memory"
-version = "0.1.1"
+version = "0.1.2"
 description = "Safe abstractions for accessing the VM physical memory"
 keywords = ["memory"]
 authors = ["Liu Jiang <gerry@linux.alibaba.com>"]

--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -501,7 +501,7 @@ pub trait GuestMemory {
             let len = std::cmp::min(cap, (count - total) as GuestUsize);
             match f(total, len as usize, start, region) {
                 // no more data
-                Ok(0) => break,
+                Ok(0) => return Ok(total),
                 // made some progress
                 Ok(len) => {
                     total += len;
@@ -687,7 +687,7 @@ impl<T: GuestMemory> Bytes<GuestAddress> for T {
     {
         self.try_access(count, addr, |offset, len, caddr, region| -> Result<usize> {
             // Check if something bad happened before doing unsafe things.
-            assert!(offset < count);
+            assert!(offset <= count);
             if let Some(dst) = unsafe { region.as_mut_slice() } {
                 // This is safe cause `start` and `len` are within the `region`.
                 let start = caddr.raw_value() as usize;
@@ -753,7 +753,7 @@ impl<T: GuestMemory> Bytes<GuestAddress> for T {
     {
         self.try_access(count, addr, |offset, len, caddr, region| -> Result<usize> {
             // Check if something bad happened before doing unsafe things.
-            assert!(offset < count);
+            assert!(offset <= count);
             if let Some(src) = unsafe { region.as_slice() } {
                 // This is safe cause `start` and `len` are within the `region`.
                 let start = caddr.raw_value() as usize;
@@ -961,5 +961,46 @@ mod tests {
     #[test]
     fn test_non_atomic_access() {
         non_atomic_access_helper::<u16>()
+    }
+
+    #[cfg(feature = "backend-mmap")]
+    #[test]
+    fn test_zero_length_accesses() {
+        #[derive(Default, Clone, Copy)]
+        #[repr(C)]
+        struct ZeroSizedStruct {
+            dummy: [u32; 0],
+        }
+
+        unsafe impl ByteValued for ZeroSizedStruct {}
+
+        let addr = GuestAddress(0x1000);
+        let mem = GuestMemoryMmap::from_ranges(&[(addr, 0x1000)]).unwrap();
+        let obj = ZeroSizedStruct::default();
+        let mut image = make_image(0x80);
+
+        assert_eq!(mem.write(&[], addr).unwrap(), 0);
+        assert_eq!(mem.read(&mut [], addr).unwrap(), 0);
+
+        assert!(mem.write_slice(&[], addr).is_ok());
+        assert!(mem.read_slice(&mut [], addr).is_ok());
+
+        assert!(mem.write_obj(obj, addr).is_ok());
+        assert!(mem.read_obj::<ZeroSizedStruct>(addr).is_ok());
+
+        assert_eq!(mem.read_from(addr, &mut Cursor::new(&image), 0).unwrap(), 0);
+
+        assert!(mem
+            .read_exact_from(addr, &mut Cursor::new(&image), 0)
+            .is_ok());
+
+        assert_eq!(
+            mem.write_to(addr, &mut Cursor::new(&mut image), 0).unwrap(),
+            0
+        );
+
+        assert!(mem
+            .write_all_to(addr, &mut Cursor::new(&mut image), 0)
+            .is_ok());
     }
 }


### PR DESCRIPTION
Related to #106 

Relax the assertions from `write_to` and `read_from` to allow equality between `offset` and `count`, which no longer leads to panics when zero-length accesses happen. This is preferred versus adding an explicit check for `count` or `len == 0` somewhere, because we don't end up with an additional branch on the regular path. Also tweaked the `try_access` logic a bit, to return `Ok(0)` when `total == 0` but we found a valid region associated with the current address (which indicates a zero-length access).