### PR TITLE
Relax assertions for zero-length accesses (for v0.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
-# [v0.2.1]
+# Changelog
 
-## Fixed
+## [v0.2.2]
+
+### Fixed
+- [[#106]](https://github.com/rust-vmm/vm-memory/issues/106): Asserts trigger
+  on zero-length access.
+
+## [v0.2.1]
+
+### Fixed
 - [[#93]](https://github.com/rust-vmm/vm-memory/issues/93): Avoid torn writes
   with memcpy.
 
-# [v0.2.0]
+## [v0.2.0]
 
-## Added
+### Added
 
 - [[#76]](https://github.com/rust-vmm/vm-memory/issues/76): Added `get_slice` and
   `as_volatile_slice` to `GuestMemoryRegion`.
@@ -16,9 +24,9 @@
   `ByteValued` which can be used for reading into POD structures from
   raw bytes.
 
-# [v0.1.0]
+## [v0.1.0]
 
-## Added
+### Added
 
 - Added traits for working with VM memory.
 - Added a mmap based implemention for the Guest Memory.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vm-memory"
-version = "0.2.1"
+version = "0.2.2"
 description = "Safe abstractions for accessing the VM physical memory"
 keywords = ["memory"]
 authors = ["Liu Jiang <gerry@linux.alibaba.com>"]

--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 86.1,
+  "coverage_score": 86,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap,backend-atomic"
 }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 86.1,
+  "coverage_score": 86,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap,backend-atomic"
 }

--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -540,7 +540,7 @@ pub trait GuestMemory {
             let len = std::cmp::min(cap, (count - total) as GuestUsize);
             match f(total, len as usize, start, region) {
                 // no more data
-                Ok(0) => break,
+                Ok(0) => return Ok(total),
                 // made some progress
                 Ok(len) => {
                     total += len;
@@ -738,7 +738,7 @@ impl<T: GuestMemory> Bytes<GuestAddress> for T {
     {
         self.try_access(count, addr, |offset, len, caddr, region| -> Result<usize> {
             // Check if something bad happened before doing unsafe things.
-            assert!(offset < count);
+            assert!(offset <= count);
             if let Some(dst) = unsafe { region.as_mut_slice() } {
                 // This is safe cause `start` and `len` are within the `region`.
                 let start = caddr.raw_value() as usize;
@@ -804,7 +804,7 @@ impl<T: GuestMemory> Bytes<GuestAddress> for T {
     {
         self.try_access(count, addr, |offset, len, caddr, region| -> Result<usize> {
             // Check if something bad happened before doing unsafe things.
-            assert!(offset < count);
+            assert!(offset <= count);
             if let Some(src) = unsafe { region.as_slice() } {
                 // This is safe cause `start` and `len` are within the `region`.
                 let start = caddr.raw_value() as usize;
@@ -1012,5 +1012,46 @@ mod tests {
     #[test]
     fn test_non_atomic_access() {
         non_atomic_access_helper::<u16>()
+    }
+
+    #[cfg(feature = "backend-mmap")]
+    #[test]
+    fn test_zero_length_accesses() {
+        #[derive(Default, Clone, Copy)]
+        #[repr(C)]
+        struct ZeroSizedStruct {
+            dummy: [u32; 0],
+        }
+
+        unsafe impl ByteValued for ZeroSizedStruct {}
+
+        let addr = GuestAddress(0x1000);
+        let mem = GuestMemoryMmap::from_ranges(&[(addr, 0x1000)]).unwrap();
+        let obj = ZeroSizedStruct::default();
+        let mut image = make_image(0x80);
+
+        assert_eq!(mem.write(&[], addr).unwrap(), 0);
+        assert_eq!(mem.read(&mut [], addr).unwrap(), 0);
+
+        assert!(mem.write_slice(&[], addr).is_ok());
+        assert!(mem.read_slice(&mut [], addr).is_ok());
+
+        assert!(mem.write_obj(obj, addr).is_ok());
+        assert!(mem.read_obj::<ZeroSizedStruct>(addr).is_ok());
+
+        assert_eq!(mem.read_from(addr, &mut Cursor::new(&image), 0).unwrap(), 0);
+
+        assert!(mem
+            .read_exact_from(addr, &mut Cursor::new(&image), 0)
+            .is_ok());
+
+        assert_eq!(
+            mem.write_to(addr, &mut Cursor::new(&mut image), 0).unwrap(),
+            0
+        );
+
+        assert!(mem
+            .write_all_to(addr, &mut Cursor::new(&mut image), 0)
+            .is_ok());
     }
 }


### PR DESCRIPTION
Related to #106

Relax the assertions from `write_to` and `read_from` to allow equality between `offset` and `count`, which no longer leads to panics when zero-length accesses happen. This is preferred versus adding an explicit check for `count` or `len == 0` somewhere, because we don't end up with an additional branch on the regular path. Also tweaked the `try_access` logic a bit, to return `Ok(0)` when `total == 0` but we found a valid region associated with the current address (which indicates a zero-length access).