### PR TITLE
mmap_unix: add support for externally managed mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - [[#106]](https://github.com/rust-vmm/vm-memory/issues/106): Asserts trigger
   on zero-length access.  
 
+### Added
+- [[#109]](https://github.com/rust-vmm/vm-memory/pull/109): Added `build_raw` to
+  `MmapRegion` which can be used to operate on externally created mappings.
+
 ## [v0.2.0]
 
 ### Added

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 85.4,
+  "coverage_score": 85.1,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap,backend-atomic"
 }


### PR DESCRIPTION
Add the unsafe MmapRegion::build_raw method to allow users to instance
MmapRegion with externally managed mappings. Add also a field to
indicate whether the mapping is internal or external, so we don't try
to munmap it on MmapRegion::Drop.

Signed-off-by: Sergio Lopez <slp@redhat.com>