### PR TITLE
mmap: try THP via madvise

### DIFF
--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -159,6 +159,15 @@ impl FileOffset {
     }
 }
 
+/// Configurations options usable for Guest Memory
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
+pub struct GuestMemoryOptions {
+    /// Use huge pages to back guest memory
+    pub huge_page: bool,
+    /// Use transparent huge pages to back guest memory
+    pub transparent_huge_page: bool,
+}
+
 /// Represents a continuous region of guest physical memory.
 #[allow(clippy::len_without_is_empty)]
 pub trait GuestMemoryRegion: Bytes<MemoryRegionAddress, E = Error> {

--- a/src/mmap_unix.rs
+++ b/src/mmap_unix.rs
@@ -154,6 +154,8 @@ impl MmapRegion {
             return Err(Error::Mmap(io::Error::last_os_error()));
         }
 
+        let _ret = unsafe { libc::madvise(addr, size, libc::MADV_HUGEPAGE) };
+
         Ok(Self {
             addr: addr as *mut u8,
             size,

--- a/src/mmap_unix.rs
+++ b/src/mmap_unix.rs
@@ -20,6 +20,7 @@ use std::result;
 use libc;
 
 use crate::guest_memory::FileOffset;
+use crate::guest_memory::GuestMemoryOptions;
 use crate::mmap::{check_file_offset, AsSlice};
 use crate::volatile_memory::{self, compute_offset, VolatileMemory, VolatileSlice};
 
@@ -93,12 +94,13 @@ impl MmapRegion {
     ///
     /// # Arguments
     /// * `size` - The size of the memory region in bytes.
-    pub fn new(size: usize) -> Result<Self> {
+    pub fn new(size: usize, options: GuestMemoryOptions) -> Result<Self> {
         Self::build(
             None,
             size,
             libc::PROT_READ | libc::PROT_WRITE,
             libc::MAP_ANONYMOUS | libc::MAP_NORESERVE | libc::MAP_PRIVATE,
+            options
         )
     }
 
@@ -108,12 +110,13 @@ impl MmapRegion {
     /// * `file_offset` - The mapping will be created at offset `file_offset.start` in the file
     ///                   referred to by `file_offset.file`.
     /// * `size` - The size of the memory region in bytes.
-    pub fn from_file(file_offset: FileOffset, size: usize) -> Result<Self> {
+    pub fn from_file(file_offset: FileOffset, size: usize, options: GuestMemoryOptions) -> Result<Self> {
         Self::build(
             Some(file_offset),
             size,
             libc::PROT_READ | libc::PROT_WRITE,
             libc::MAP_NORESERVE | libc::MAP_SHARED,
+            options
         )
     }
 
@@ -132,6 +135,7 @@ impl MmapRegion {
         size: usize,
         prot: i32,
         flags: i32,
+        options: GuestMemoryOptions,
     ) -> Result<Self> {
         // Forbid MAP_FIXED, as it doesn't make sense in this context, and is pretty dangerous
         // in general.
@@ -154,7 +158,13 @@ impl MmapRegion {
             return Err(Error::Mmap(io::Error::last_os_error()));
         }
 
-        let _ret = unsafe { libc::madvise(addr, size, libc::MADV_HUGEPAGE) };
+        if options.huge_page {
+            if options.transparent_huge_page {
+                if size > 2 * 1024 * 4096 {
+                    let _ret = unsafe { libc::madvise(addr, size, libc::MADV_HUGEPAGE) };
+                }
+            }
+        }
 
         Ok(Self {
             addr: addr as *mut u8,


### PR DESCRIPTION
Huge pages bring performance benefits for memory intensive applications.
A simple way to use huge pages is by using transparent huge pages. This
can be done by either using statically pre-reserved huge pages, or by
using transparent huge pages.

While some distributions enable transparent huge pages by default, other
distributions chose to allow this feature only when the madvise system
call is used.

This change adds the madvise system call to the memory allocation. On
Unix systems, the invocation of mmap is followed with an madvise system
call that asks the kernel to back the memory with transparent huge
pages, if possible.

Note: this is a prototypical implementation of getting huge page
support. No performance testing has been performed yet. We expect
similar results as reported in https://arxiv.org/abs/2004.14378
Once this data is available, a configuration layer should be added to
be able to disable or enable this change.

Signed-off-by: Norbert Manthey <nmanthey@amazon.de>

# Testing Done

Currently, I only compiled firecracker with the change, and will run it's test suite next and add the results here, as well as look into performance testing.

The test suite mostly passes, except some tests that fail due to time outs, which might depend on me using a mobile CPU for testing.

## Update dependencies

```
firecracker$ cargo update
    Updating crates.io index
    Updating git repository `https://github.com/firecracker-microvm/kvm-bindings`
    Updating git repository `https://github.com/firecracker-microvm/kvm-ioctls`
...
    Updating unicode-xid v0.2.0 -> v0.2.1
      Adding vm-memory v0.2.2 ($HOME/firecracker/local-crates/vm-memory)
    Removing vm-memory v0.2.2
    Updating winapi v0.3.8 -> v0.3.9
```


## Actually Build

```
firecracker$ tools/devtool build |& tee build.log
[Firecracker devtool] Starting build (debug, musl) ...
 Downloading crates ...
...
   Compiling vmm-sys-util v0.6.1
   Compiling vm-memory v0.2.2 (/firecracker/local-crates/vm-memory)
   Compiling timerfd v1.1.1
...
    Finished dev [unoptimized + debuginfo] target(s) in 38.89s
[Firecracker devtool] Build successful.
[Firecracker devtool] Binaries placed under $HOME/firecracker/build/cargo_target/x86_64-unknown-linux-musl/debug
```

## Required Changes in Firecracker (to pick up this change)

Place this vm-memory repository into "local-crates/vm-memory" in the firecracker repository.

In firecracker, use the following changes on top of the (current) master commit:

```
firecracker$ git diff HEAD^^
diff --git a/Cargo.toml b/Cargo.toml
index 799712f7..88da28f0 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,9 @@
 [workspace]
 members = ["src/firecracker", "src/jailer"]

+[patch.crates-io]
+vm-memory = { path = 'local-crates/vm-memory' }
+
 [profile.dev]
 panic = "abort"

diff --git a/tools/devtool b/tools/devtool
index 2c2a9551..d870cef5 100755
--- a/tools/devtool
+++ b/tools/devtool
@@ -367,6 +367,7 @@ run_devctr() {
     # Use 'z' on the --volume parameter for docker to automatically relabel the
     # content and allow sharing between containers.
     docker run "${docker_args[@]}" \
+        --network=host \
         --rm \
         --volume /dev:/dev \
         --volume "$FC_ROOT_DIR:$CTR_FC_ROOT_DIR:z" \
```