### PR TITLE
[RFC] vm-memory refactoring proposal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ autobenches = false
 
 [features]
 default = []
-integer-atomics = []
 backend-mmap = []
 backend-atomic = ["arc-swap"]
 

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -18,7 +18,7 @@ pub fn criterion_benchmark(_c: &mut Criterion) {
 
 criterion_group! {
     name = benches;
-    config = Criterion::default().sample_size(200).measurement_time(std::time::Duration::from_secs(50));
+    config = Criterion::default().sample_size(200).measurement_time(std::time::Duration::from_secs(30));
     targets = criterion_benchmark
 }
 

--- a/benches/mmap/mod.rs
+++ b/benches/mmap/mod.rs
@@ -69,7 +69,7 @@ pub fn benchmark_for_mmap(c: &mut Criterion) {
     // contiguous w.r.t. GPAs to do the same for HVAs, we need to manually ensure this holds for
     // our region configuration (until we provide functionality for building, and not just checking
     // in `vm-memory`. We're using a quick approach where we allocate one large region, which is
-    // then used to build subregions based on `MmapRegion::build_raw`. 
+    // then used to build subregions based on `MmapRegion::build_raw`.
     let helper_region = MmapRegion::new((REGION_SIZE * REGIONS_COUNT) as usize).unwrap();
     let memory = GuestMemoryMmap::from_regions(
         (0..REGIONS_COUNT as usize)

--- a/src/access.rs
+++ b/src/access.rs
@@ -1,0 +1,241 @@
+use std::cmp;
+use std::io::{Read, Write};
+use std::mem::size_of;
+use std::ptr;
+use std::result;
+
+use crate::{copy_bytes, ByteValued, Bytes, GuestMemoryError};
+
+// This module contains internal (they don't need to be explicitly brought into scope or otherwise
+// acknowledged by consumers of `vm-memory`) helper abstractions which provide a single
+// implementation for all related functionality in `vm-memory` right now (for example, all
+// types implementing `Bytes` leverage the logic in this file instead of defining their own).
+// Moreover, they also offer a simple manner to automatically implement functionality for
+// all relevant objects.
+//
+// Most methods/objects here have `pub` visibility, but the module itself is not public.
+
+pub type Result<T> = result::Result<T, GuestMemoryError>;
+
+// Stands for a contiguous region of host virtual memory.
+pub trait HostRegion {
+    // The starting address of the region.
+    fn as_ptr(&self) -> *mut u8;
+    // The legnth of the region.
+    fn len(&self) -> usize;
+
+    // Computes the resulting address without checking the addition operation for overflow.
+    fn offset_unchecked(&self, offset: usize) -> *mut u8 {
+        ((self.as_ptr() as usize) + offset) as *mut u8
+    }
+}
+
+// Stands for an address space that can be queried whether an access at a given address and
+// with a specified length is valid. For example, we can ask a `GuestMemory` object if we can
+// read/write a number of bytes starting with some address. The input address depends on the
+// implementor, but the output addresses are always host virtual. We leverage the assumption
+// that cross region accesses no longer require special handling.
+pub trait CheckAccess<A> {
+    // Check whether an access starting at `addr` for exactly `len` bytes is valid, and return
+    // the starting HVA if successful.
+    fn check_access(&self, addr: A, len: usize) -> Result<*mut u8>;
+
+    // Check whether an access starting at `addr` for at most `max_len` bytes is valid, and
+    // return the starting HVA and allowed length if successful.
+    fn check_partial_access(&self, addr: A, max_len: usize) -> Result<(*mut u8, usize)>;
+}
+
+// A type implementing `HostRegion` can be seen as an array of bytes in host virtual memory, so
+// we can implement `CheckAccess<usize>` automatically from that perspective (the address is
+// basically an offset in this case).
+impl<T: HostRegion> CheckAccess<usize> for T {
+    fn check_access(&self, offset: usize, len: usize) -> Result<*mut u8> {
+        if let Some(end) = offset.checked_add(len) {
+            if end <= self.len() {
+                // It's ok to use `offset_unchecked` because we previously verified there's
+                // no overflow.
+                return Ok(self.offset_unchecked(offset));
+            }
+        }
+        Err(GuestMemoryError::InvalidAccess)
+    }
+
+    fn check_partial_access(&self, offset: usize, max_len: usize) -> Result<(*mut u8, usize)> {
+        if offset <= self.len() {
+            if let Some(end) = offset.checked_add(max_len) {
+                let min = cmp::min(self.len(), end);
+                let access_len = min - offset;
+                // It's ok to use `offset_unchecked` because we previously verified there's
+                // no overflow.
+                return Ok((self.offset_unchecked(offset), access_len));
+            }
+        }
+        Err(GuestMemoryError::InvalidAccess)
+    }
+}
+
+// Implementing this trait for a type `T` will automatically add a `Bytes` implementation for `T`,
+// based on the logic below.
+pub trait AutoBytes<A>: CheckAccess<A> {}
+
+// This is an internal helper struct (like the one already existing in `vm-memory`) which can
+// be used to do volatile object accesses for addresses which might not be aligned. Working
+// with packed objects has quite a number of caveats in Rust, so we don't expose this to the
+// outside.
+#[repr(packed)]
+struct Packed<T>(T);
+
+// Helper function for reading bytes from a `Read` source into a memory location.//
+//
+// # Safety
+//
+// The function is safe to call only if (`ptr`, `len`) is valid for writes.
+unsafe fn help_read_from<R: Read>(mut src: R, ptr: *mut u8, len: usize) -> Result<usize> {
+    // Safe because `ptr` and `len` are valid for writes.
+    let dst = std::slice::from_raw_parts_mut(ptr, len);
+    let mut total = 0;
+    while total < len {
+        match src.read(&mut dst[total..len]) {
+            Ok(n) => match n {
+                0 => return Ok(total),
+                _ => total += n,
+            },
+            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(GuestMemoryError::IOError(e)),
+        }
+    }
+    Ok(total)
+}
+
+// Helper function for reading bytes from a memory location into a `Write` destination.
+//
+// # Safety
+//
+// The function is safe to call only if (`ptr`, `len`) is valid for reads.
+unsafe fn help_write_to<W: Write>(ptr: *const u8, mut dst: W, len: usize) -> Result<usize> {
+    // Safe because `ptr` and `len` are valid for reads.
+    let src = std::slice::from_raw_parts(ptr, len);
+    let mut total = 0;
+    while total < len {
+        match dst.write(&src[total..len]) {
+            Ok(n) => match n {
+                0 => return Ok(total),
+                _ => total += n,
+            },
+            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(GuestMemoryError::IOError(e)),
+        }
+    }
+    Ok(total)
+}
+
+// Provides an automatic `Bytes` implementation for `C`, based on `C: CheckAccess<A>` (which
+// is implied by `C: AutoBytes<A>`. The reason we define and use `AutoBytes` instead of having
+// a `CheckAccess` bound here directly is to avoid generating the implementation unless
+// explicitly requested to. The logic defined here will be used by all `Bytes` implementors
+// within `vm-memory`.
+impl<A, C: AutoBytes<A>> Bytes<A> for C {
+    type E = GuestMemoryError;
+
+    // All methods here make extensive use of `CheckAccess`.
+    fn write(&self, buf: &[u8], addr: A) -> Result<usize> {
+        // A `write` can be partial so we query the validity and allowed length first.
+        self.check_partial_access(addr, buf.len())
+            .map(|(ptr, len)| {
+                // If we get here, `ptr` and `len` have been checked to be valid, so it's
+                // safe to proceed with copying the bytes.
+                unsafe {
+                    copy_bytes(buf.as_ptr(), ptr, len);
+                    len
+                }
+            })
+    }
+
+    fn read(&self, buf: &mut [u8], addr: A) -> Result<usize> {
+        self.check_partial_access(addr, buf.len())
+            .map(|(ptr, len)| {
+                // Safe because (`ptr`, `len`) is guaranteed to be valid for access.
+                unsafe {
+                    copy_bytes(ptr, buf.as_mut_ptr(), len);
+                    len
+                }
+            })
+    }
+
+    fn write_slice(&self, buf: &[u8], addr: A) -> Result<()> {
+        // The caller wants to write the full contents of the slice, so we use `check_access`
+        // with the desired `len`.
+        self.check_access(addr, buf.len()).map(|ptr| {
+            // Safe because ...
+            unsafe { copy_bytes(buf.as_ptr(), ptr, buf.len()) };
+        })
+    }
+
+    fn read_slice(&self, buf: &mut [u8], addr: A) -> Result<()> {
+        self.check_access(addr, buf.len()).map(|ptr| {
+            // Safe because (`ptr`, `len`) is guaranteed to be valid for access.
+            unsafe { copy_bytes(ptr, buf.as_mut_ptr(), buf.len()) };
+        })
+    }
+
+    fn write_obj<T: ByteValued>(&self, val: T, addr: A) -> Result<()> {
+        // We check for an access equal to the size of the object.
+        self.check_access(addr, size_of::<T>()).map(|ptr| {
+            // Safe because (`ptr`, `len`) is guaranteed to be valid for access, and
+            // passing a `Packed<T>` ensures alignment doesn't matter.
+            unsafe { ptr::write_volatile(ptr as *mut Packed<T>, Packed(val)) }
+        })
+    }
+
+    fn read_obj<T: ByteValued>(&self, addr: A) -> Result<T> {
+        self.check_access(addr, size_of::<T>()).map(|ptr| {
+            // Safe because (`ptr`, `len`) is guaranteed to be valid for access, and
+            // using the `Packed<T>` type ensures alignment doesn't matter.
+            unsafe { ptr::read_volatile(ptr as *const Packed<T>).0 }
+        })
+    }
+
+    fn read_from<R: Read>(&self, addr: A, src: &mut R, count: usize) -> Result<usize> {
+        self.check_partial_access(addr, count)
+            // Safe because (`ptr`, `len`) is guaranteed to be valid for access.
+            .and_then(|(ptr, len)| unsafe { help_read_from(src, ptr, len) })
+    }
+
+    fn read_exact_from<R: Read>(&self, addr: A, src: &mut R, count: usize) -> Result<()> {
+        self.check_access(addr, count)
+            // Safe because (`ptr`, `len`) is guaranteed to be valid for access.
+            .and_then(|ptr| unsafe { help_read_from(src, ptr, count) })
+            .and_then(|actual_count| {
+                if actual_count != count {
+                    Err(GuestMemoryError::PartialBuffer {
+                        expected: count,
+                        completed: actual_count,
+                    })
+                } else {
+                    Ok(())
+                }
+            })
+    }
+
+    fn write_to<W: Write>(&self, addr: A, dst: &mut W, count: usize) -> Result<usize> {
+        self.check_partial_access(addr, count)
+            // Safe because (`ptr`, `len`) is guaranteed to be valid for access.
+            .and_then(|(ptr, len)| unsafe { help_write_to(ptr, dst, len) })
+    }
+
+    fn write_all_to<W: Write>(&self, addr: A, dst: &mut W, count: usize) -> Result<()> {
+        self.check_access(addr, count)
+            // Safe because (`ptr`, `len`) is guaranteed to be valid for access.
+            .and_then(|ptr| unsafe { help_write_to(ptr, dst, count) })
+            .and_then(|actual_count| {
+                if actual_count != count {
+                    Err(GuestMemoryError::PartialBuffer {
+                        expected: count,
+                        completed: actual_count,
+                    })
+                } else {
+                    Ok(())
+                }
+            })
+    }
+}

--- a/src/align.rs
+++ b/src/align.rs
@@ -1,0 +1,102 @@
+//! Provides abstractions (often effectively zero-cost) for modeling the alignment
+//! of addresses by leveraging the type system.
+
+use std::convert::TryFrom;
+use std::marker::PhantomData;
+use std::mem::align_of;
+use std::result;
+
+use crate::{Address, GuestMemoryError};
+
+// Check whether `addr` is aligned with respect to `T`.
+fn check_alignment<Addr: Address, T>(addr: Addr) -> result::Result<(), GuestMemoryError> {
+    // The value returned from `align_of` should fit within an `u8`
+    // for the foreseeable future.
+    let align = u8::try_from(align_of::<T>()).unwrap();
+    let aligned_addr = addr
+        .checked_align_up(Addr::V::from(align))
+        .ok_or(GuestMemoryError::Overflow)?;
+    if addr == aligned_addr {
+        Ok(())
+    } else {
+        Err(GuestMemoryError::Misaligned)
+    }
+}
+
+/// An address that's aligned with respect to `T`.
+#[derive(Clone, Copy)]
+pub struct Aligned<Addr, T> {
+    addr: Addr,
+    phantom: PhantomData<*const T>,
+}
+
+impl<Addr, T> Aligned<Addr, T> {
+    /// Instantiate a new `Aligned` value without checking the alignment.
+    ///
+    /// # Safety
+    ///
+    /// The value of `addr` must be aligned with respect to `T`.
+    pub unsafe fn new(addr: Addr) -> Self {
+        Aligned {
+            addr,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Return the inner address value.
+    pub fn into(self) -> Addr {
+        self.addr
+    }
+
+    /// Convert `self` into an `Aligned` value with the specified alignment without
+    /// performing any checks.
+    ///
+    /// # Safety
+    ///
+    /// The inner address value must be aligned with respect to `U`.
+    pub unsafe fn reinterpret<U>(self) -> Aligned<Addr, U> {
+        Aligned::new(self.addr)
+    }
+}
+
+impl<Addr: Address, T> Aligned<Addr, T> {
+    /// Attempt to create an `Aligned` value based on `addr`.
+    pub fn try_from(addr: Addr) -> result::Result<Self, GuestMemoryError> {
+        check_alignment::<Addr, T>(addr).map(|_| {
+            // Safe because we checked the alignment.
+            unsafe { Self::new(addr) }
+        })
+    }
+
+    /// Attempt to convert `self` into an `Aligned` value with the specified alignment.
+    pub fn cast<U>(self) -> result::Result<Aligned<Addr, U>, GuestMemoryError> {
+        // Fast (compile time) conversion path.
+        if align_of::<T>() >= align_of::<U>() {
+            // Safe because the above inequality holds.
+            Ok(unsafe { self.reinterpret::<U>() })
+        } else {
+            Aligned::try_from(self.addr)
+        }
+    }
+
+    /// Attempt to obtain an `Aligned<Addr, U>` after offsetting the current address by `value`.
+    pub fn offset<U>(self, value: Addr::V) -> result::Result<Aligned<Addr, U>, GuestMemoryError> {
+        let addr = self
+            .addr
+            .checked_add(value)
+            .ok_or(GuestMemoryError::Overflow)?;
+
+        // Fast path.
+        if align_of::<T>() >= align_of::<U>() {
+            // We only need to check if the offset value is aligned here w.r.t. `U`, because we
+            // know the base is aligned from the condition above. This check can be optimized
+            // away in certain conditions (i.e. when `value` is known at compile time).
+            check_alignment::<Addr, U>(Addr::new(value)).map(|_| {
+                // Safe because the above checks/conditions ensure `addr` is properly aligned.
+                unsafe { Aligned::new(addr) }
+            })
+        } else {
+            Aligned::try_from(addr)
+        }
+    }
+}

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -17,6 +17,34 @@ use std::mem::size_of;
 use std::result::Result;
 use std::slice::{from_raw_parts, from_raw_parts_mut};
 
+/// Objects that implement this trait must consist exclusively of atomic types
+/// from [`std::sync::atomic`](https://doc.rust-lang.org/std/sync/atomic/), except for
+/// [`AtomicPtr<T>`](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicPtr.html) and
+/// [`AtomicBool`](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicBool.html).
+pub unsafe trait AtomicInteger: Sync + Send {}
+
+// TODO: Detect availability using #[cfg(target_has_atomic) when it is stabilized.
+// Right now we essentially assume we're running on either x86 or Arm (32 or 64 bit). AFAIK,
+// Rust starts using additional synchronization primitives to implement atomics when they're
+// not natively available, and that doesn't interact safely with how we cast pointers to
+// atomic value references. We should be wary of this when looking at a broader range of
+// platforms.
+
+unsafe impl AtomicInteger for std::sync::atomic::AtomicI8 {}
+unsafe impl AtomicInteger for std::sync::atomic::AtomicI16 {}
+unsafe impl AtomicInteger for std::sync::atomic::AtomicI32 {}
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+unsafe impl AtomicInteger for std::sync::atomic::AtomicI64 {}
+
+unsafe impl AtomicInteger for std::sync::atomic::AtomicU8 {}
+unsafe impl AtomicInteger for std::sync::atomic::AtomicU16 {}
+unsafe impl AtomicInteger for std::sync::atomic::AtomicU32 {}
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+unsafe impl AtomicInteger for std::sync::atomic::AtomicU64 {}
+
+unsafe impl AtomicInteger for std::sync::atomic::AtomicIsize {}
+unsafe impl AtomicInteger for std::sync::atomic::AtomicUsize {}
+
 /// Types for which it is safe to initialize from raw data.
 ///
 /// A type `T` is `ByteValued` if and only if it can be initialized by reading its contents from a

--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -49,6 +49,10 @@ use crate::volatile_memory;
 #[allow(missing_docs)]
 #[derive(Debug)]
 pub enum Error {
+    // TODO: This variant is a generic error that we'll use for some operations until we
+    // have a better look at error handling within `vm-memory` as well.
+    /// Attempted to perform an invalid access.
+    InvalidAccess,
     /// Failure in finding a guest address in any memory regions mapped by this guest.
     InvalidGuestAddress(GuestAddress),
     /// Couldn't read/write from the given source.
@@ -89,6 +93,7 @@ impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Guest memory error: ")?;
         match self {
+            Error::InvalidAccess => write!(f, "invalid access"),
             Error::InvalidGuestAddress(addr) => {
                 write!(f, "invalid guest address {}", addr.raw_value())
             }

--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -42,6 +42,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::address::{Address, AddressValue};
+use crate::align::Aligned;
 use crate::bytes::Bytes;
 use crate::volatile_memory;
 
@@ -63,6 +64,10 @@ pub enum Error {
     InvalidBackendAddress,
     /// Host virtual address not available.
     HostAddressNotAvailable,
+    /// Misaligned address provided.
+    Misaligned,
+    /// Overflow occurred while computing an address value.
+    Overflow,
 }
 
 impl From<volatile_memory::Error> for Error {
@@ -108,6 +113,8 @@ impl Display for Error {
             ),
             Error::InvalidBackendAddress => write!(f, "invalid backend address"),
             Error::HostAddressNotAvailable => write!(f, "host virtual address not available"),
+            Error::Misaligned => write!(f, "misaligned address"),
+            Error::Overflow => write!(f, "overflow detected"),
         }
     }
 }
@@ -122,10 +129,16 @@ impl Display for Error {
 pub struct GuestAddress(pub u64);
 impl_address_ops!(GuestAddress, u64);
 
+/// A `GuestAddress` that's known to be aligned with respect to `T`.
+pub type AlignedGuestAddress<T> = Aligned<GuestAddress, T>;
+
 /// Represents an offset inside a region.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct MemoryRegionAddress(pub u64);
 impl_address_ops!(MemoryRegionAddress, u64);
+
+/// A `MemoryRegionAddress` that's known to be aligned with respect to `T`.
+pub type AlignedMemoryRegionAddress<T> = Aligned<MemoryRegionAddress, T>;
 
 /// Type of the raw value stored in a `GuestAddress` object.
 pub type GuestUsize = <GuestAddress as AddressValue>::V;

--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -43,7 +43,7 @@ use std::sync::Arc;
 
 use crate::address::{Address, AddressValue};
 use crate::align::Aligned;
-use crate::bytes::Bytes;
+use crate::bytes::AlignedBytes;
 use crate::volatile_memory;
 
 /// Errors associated with handling guest memory accesses.
@@ -179,7 +179,7 @@ impl FileOffset {
 
 /// Represents a continuous region of guest physical memory.
 #[allow(clippy::len_without_is_empty)]
-pub trait GuestMemoryRegion: Bytes<MemoryRegionAddress, E = Error> {
+pub trait GuestMemoryRegion: AlignedBytes<MemoryRegionAddress, E = Error> {
     /// Returns the size of the region.
     fn len(&self) -> GuestUsize;
 
@@ -418,7 +418,7 @@ impl<M: GuestMemory> GuestAddressSpace for Arc<M> {
 /// The task of the `GuestMemory` trait are:
 /// - map a request address to a `GuestMemoryRegion` object and relay the request to it.
 /// - handle cases where an access request spanning two or more `GuestMemoryRegion` objects.
-pub trait GuestMemory: Bytes<GuestAddress, E = Error> {
+pub trait GuestMemory: AlignedBytes<GuestAddress, E = Error> {
     /// Type of objects hosted by the address space.
     type R: GuestMemoryRegion;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@
 #![deny(clippy::doc_markdown)]
 #![deny(missing_docs)]
 
+mod access;
+
 #[macro_use]
 pub mod address;
 pub use address::{Address, AddressValue};
@@ -56,3 +58,11 @@ pub use volatile_memory::{
     AtomicValued, Error as VolatileMemoryError, Result as VolatileMemoryResult, VolatileArrayRef,
     VolatileMemory, VolatileRef, VolatileSlice,
 };
+
+// Previous attempts showed it's not really obvious which is the fastest (best?) approach to
+// bulk byte copies. This method is meant to be called whenever a copy is necessary,  so we can
+// easily change the behaviour in the future by altering its actual implementation. For now, we
+// simply rely on `std::ptr::copy_nonoverlapping`, which should be equivalent to `memcpy`.
+unsafe fn copy_bytes(src: *const u8, dst: *mut u8, len: usize) {
+    std::ptr::copy_nonoverlapping(src, dst, len)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,9 @@ mod access;
 pub mod address;
 pub use address::{Address, AddressValue};
 
+pub mod align;
+pub use align::Aligned;
+
 #[cfg(feature = "backend-atomic")]
 pub mod atomic;
 #[cfg(feature = "backend-atomic")]
@@ -38,8 +41,9 @@ pub use endian::{Be16, Be32, Be64, BeSize, Le16, Le32, Le64, LeSize};
 
 pub mod guest_memory;
 pub use guest_memory::{
-    Error as GuestMemoryError, FileOffset, GuestAddress, GuestAddressSpace, GuestMemory,
-    GuestMemoryRegion, GuestUsize, MemoryRegionAddress, Result as GuestMemoryResult,
+    AlignedGuestAddress, AlignedMemoryRegionAddress, Error as GuestMemoryError, FileOffset,
+    GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryRegion, GuestUsize,
+    MemoryRegionAddress, Result as GuestMemoryResult,
 };
 
 #[cfg(all(feature = "backend-mmap", unix))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,11 @@ mod access;
 pub mod address;
 pub use address::{Address, AddressValue};
 
+#[cfg(feature = "backend-atomic")]
+pub mod atomic;
+#[cfg(feature = "backend-atomic")]
+pub use atomic::{GuestMemoryAtomic, GuestMemoryLoadGuard};
+
 pub mod bytes;
 pub use bytes::{ByteValued, Bytes};
 
@@ -48,10 +53,8 @@ pub mod mmap;
 #[cfg(feature = "backend-mmap")]
 pub use mmap::{Error, GuestMemoryMmap, GuestRegionMmap, MmapRegion};
 
-#[cfg(feature = "backend-atomic")]
-pub mod atomic;
-#[cfg(feature = "backend-atomic")]
-pub use atomic::{GuestMemoryAtomic, GuestMemoryLoadGuard};
+pub mod refs;
+pub use refs::{ArrayRef, Ref};
 
 pub mod volatile_memory;
 pub use volatile_memory::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub mod atomic;
 #[cfg(feature = "backend-atomic")]
 pub use atomic::{GuestMemoryAtomic, GuestMemoryLoadGuard};
 
-pub mod bytes;
+mod bytes;
 pub use bytes::{AlignedBytes, ByteValued, Bytes};
 
 pub mod endian;
@@ -62,8 +62,8 @@ pub use refs::{ArrayRef, Ref};
 
 pub mod volatile_memory;
 pub use volatile_memory::{
-    AtomicValued, Error as VolatileMemoryError, Result as VolatileMemoryResult, VolatileArrayRef,
-    VolatileMemory, VolatileRef, VolatileSlice,
+    Error as VolatileMemoryError, Result as VolatileMemoryResult, VolatileArrayRef, VolatileMemory,
+    VolatileRef, VolatileSlice,
 };
 
 // Previous attempts showed it's not really obvious which is the fastest (best?) approach to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub mod atomic;
 pub use atomic::{GuestMemoryAtomic, GuestMemoryLoadGuard};
 
 pub mod bytes;
-pub use bytes::{ByteValued, Bytes};
+pub use bytes::{AlignedBytes, ByteValued, Bytes};
 
 pub mod endian;
 pub use endian::{Be16, Be32, Be64, BeSize, Le16, Le32, Le64, LeSize};

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -19,7 +19,7 @@ use std::ops::Deref;
 use std::result;
 use std::sync::Arc;
 
-use crate::access::{AutoBytes, CheckAccess, HostRegion};
+use crate::access::{AutoAlignedBytes, AutoBytes, CheckAccess, HostRegion};
 use crate::guest_memory::{
     self, FileOffset, GuestAddress, GuestMemory, GuestMemoryRegion, GuestUsize, MemoryRegionAddress,
 };
@@ -184,6 +184,10 @@ impl CheckAccess<MemoryRegionAddress> for GuestRegionMmap {
 
 // Provides an automatic `Bytes` implementation based on `CheckAccess<MemoryRegionAddress>`.
 impl AutoBytes<MemoryRegionAddress> for GuestRegionMmap {}
+
+// Provides the automatic `AlignedBytes` implementation based on `CheckAccess<MemoryRegionAddress>`.
+// Safe because `GuestRegionMmap` objects are aligned to a page boundary.
+unsafe impl AutoAlignedBytes<MemoryRegionAddress> for GuestRegionMmap {}
 
 impl GuestMemoryRegion for GuestRegionMmap {
     fn len(&self) -> GuestUsize {
@@ -503,6 +507,10 @@ impl CheckAccess<GuestAddress> for GuestMemoryMmap {
 
 // Provides the automatic `Bytes` implementation based on `CheckAccess<GuestAddress>`.
 impl AutoBytes<GuestAddress> for GuestMemoryMmap {}
+
+// Provides the automatic `AlignedBytes` implementation based on `CheckAccess<GuestAddress>`. Safe
+// because `GuestMemoryMmap` objects are aligned to a page boundary.
+unsafe impl AutoAlignedBytes<GuestAddress> for GuestMemoryMmap {}
 
 impl GuestMemory for GuestMemoryMmap {
     type R = GuestRegionMmap;

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -517,6 +517,240 @@ impl GuestMemoryMmap {
     }
 }
 
+impl Bytes<GuestAddress> for GuestMemoryMmap {
+    type E = guest_memory::Error;
+
+    fn write(&self, buf: &[u8], addr: GuestAddress) -> Result<usize, Self::E> {
+        self.try_access(
+            buf.len(),
+            addr,
+            |offset, _count, caddr, region| -> Result<usize, Self::E> {
+                region.write(&buf[offset as usize..], caddr)
+            },
+        )
+    }
+
+    fn read(&self, buf: &mut [u8], addr: GuestAddress) -> Result<usize, Self::E> {
+        self.try_access(
+            buf.len(),
+            addr,
+            |offset, _count, caddr, region| -> Result<usize, Self::E> {
+                region.read(&mut buf[offset as usize..], caddr)
+            },
+        )
+    }
+
+    /// # Examples
+    /// * Write a slice at guestaddress 0x200.
+    ///
+    /// ```
+    /// # #[cfg(feature = "backend-mmap")]
+    /// # use vm_memory::{Bytes, GuestAddress, mmap::GuestMemoryMmap};
+    ///
+    /// # #[cfg(feature = "backend-mmap")]
+    /// # fn test_write_u64() {
+    ///     let start_addr = GuestAddress(0x1000);
+    ///     let mut gm =
+    ///             GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)])
+    ///             .expect("Could not create guest memory");
+    ///     let res = gm.write_slice(&[1, 2, 3, 4, 5], start_addr);
+    ///     assert!(res.is_ok());
+    /// # }
+    ///
+    /// # #[cfg(feature = "backend-mmap")]
+    /// # test_write_u64();
+    /// ```
+    fn write_slice(&self, buf: &[u8], addr: GuestAddress) -> Result<(), Self::E> {
+        let res = self.write(buf, addr)?;
+        if res != buf.len() {
+            return Err(Self::E::PartialBuffer {
+                expected: buf.len(),
+                completed: res,
+            });
+        }
+        Ok(())
+    }
+
+    /// # Examples
+    /// * Read a slice of length 16 at guestaddress 0x200.
+    ///
+    /// ```
+    /// # #[cfg(feature = "backend-mmap")]
+    /// # use vm_memory::{Bytes, GuestAddress, mmap::GuestMemoryMmap};
+    ///
+    /// # #[cfg(feature = "backend-mmap")]
+    /// # fn test_write_u64() {
+    ///     let start_addr = GuestAddress(0x1000);
+    ///     let mut gm =
+    ///             GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)])
+    ///             .expect("Could not create guest memory");
+    ///     let buf = &mut [0u8; 16];
+    ///     let res = gm.read_slice(buf, start_addr);
+    ///     assert!(res.is_ok());
+    /// # }
+    ///
+    /// # #[cfg(feature = "backend-mmap")]
+    /// # test_write_u64()
+    /// ```
+    fn read_slice(&self, buf: &mut [u8], addr: GuestAddress) -> Result<(), Self::E> {
+        let res = self.read(buf, addr)?;
+        if res != buf.len() {
+            return Err(Self::E::PartialBuffer {
+                expected: buf.len(),
+                completed: res,
+            });
+        }
+        Ok(())
+    }
+
+    /// # Examples
+    ///
+    /// * Read bytes from /dev/urandom
+    ///
+    /// ```
+    /// # #[cfg(feature = "backend-mmap")]
+    /// # use vm_memory::{Address, Bytes, GuestAddress, mmap::GuestMemoryMmap};
+    /// # use std::fs::File;
+    /// # use std::path::Path;
+    ///
+    /// # #[cfg(all(unix, feature = "backend-mmap"))]
+    /// # fn test_read_random() {
+    ///     let start_addr = GuestAddress(0x1000);
+    ///     let gm =
+    ///         GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)])
+    ///         .expect("Could not create guest memory");
+    ///     let mut file = File::open(Path::new("/dev/urandom"))
+    ///         .expect("could not open /dev/urandom");
+    ///     let addr = GuestAddress(0x1010);
+    ///     gm.read_from(addr, &mut file, 128)
+    ///         .expect("Could not read from /dev/urandom into guest memory");
+    ///     let read_addr = addr.checked_add(8).expect("Could not compute read address");
+    ///     let rand_val: u32 = gm
+    ///         .read_obj(read_addr)
+    ///         .expect("Could not read u32 val from /dev/urandom");
+    /// # }
+    ///
+    /// # #[cfg(all(unix, feature = "backend-mmap"))]
+    /// # test_read_random();
+    /// ```
+    fn read_from<F>(&self, addr: GuestAddress, src: &mut F, count: usize) -> Result<usize, Self::E>
+    where
+        F: Read,
+    {
+        self.try_access(
+            count,
+            addr,
+            |offset, len, caddr, region| -> Result<usize, Self::E> {
+                // Check if something bad happened before doing unsafe things.
+                assert!(offset <= count);
+                // `GuestRegionMmap` always provides `as_mut_slice`.
+                let dst = unsafe { region.as_mut_slice() }.unwrap();
+                // This is safe cause `start` and `len` are within the `region`.
+                let start = caddr.raw_value() as usize;
+                let end = start + len;
+                loop {
+                    match src.read(&mut dst[start..end]) {
+                        Ok(n) => break Ok(n),
+                        Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                        Err(e) => break Err(Self::E::IOError(e)),
+                    }
+                }
+            },
+        )
+    }
+
+    fn read_exact_from<F>(
+        &self,
+        addr: GuestAddress,
+        src: &mut F,
+        count: usize,
+    ) -> Result<(), Self::E>
+    where
+        F: Read,
+    {
+        let res = self.read_from(addr, src, count)?;
+        if res != count {
+            return Err(Self::E::PartialBuffer {
+                expected: count,
+                completed: res,
+            });
+        }
+        Ok(())
+    }
+
+    /// # Examples
+    ///
+    /// * Write 128 bytes to /dev/null
+    ///
+    /// ```
+    /// # #[cfg(feature = "backend-mmap")]
+    /// # use vm_memory::{Bytes, GuestAddress, mmap::GuestMemoryMmap};
+    /// # use std::fs::OpenOptions;
+    /// # use std::path::Path;
+    ///
+    /// # #[cfg(all(unix, feature = "backend-mmap"))]
+    /// # fn test_write_null() {
+    ///     let start_addr = GuestAddress(0x1000);
+    ///     let gm =
+    ///         GuestMemoryMmap::from_ranges(&vec![(start_addr, 1024)])
+    ///         .expect("Could not create guest memory");
+    ///     let mut file = OpenOptions::new()
+    ///         .write(true)
+    ///         .open("/dev/null")
+    ///         .expect("Could not open /dev/null");
+    ///
+    ///     gm.write_to(start_addr, &mut file, 128)
+    ///         .expect("Could not write 128 bytes to the provided address");
+    /// # }
+    ///
+    /// # #[cfg(all(unix, feature = "backend-mmap"))]
+    /// # test_write_null();
+    /// ```
+    fn write_to<F>(&self, addr: GuestAddress, dst: &mut F, count: usize) -> Result<usize, Self::E>
+    where
+        F: Write,
+    {
+        self.try_access(
+            count,
+            addr,
+            |offset, len, caddr, region| -> Result<usize, Self::E> {
+                // Check if something bad happened before doing unsafe things.
+                assert!(offset <= count);
+                // `GuestRegionMmap` always provides `as_slice`.
+                let src = unsafe { region.as_slice() }.unwrap();
+                // This is safe cause `start` and `len` are within the `region`.
+                let start = caddr.raw_value() as usize;
+                let end = start + len;
+                loop {
+                    // It is safe to read from volatile memory. Accessing the guest
+                    // memory as a slice should be OK as long as nothing assumes another
+                    // thread won't change what is loaded; however, we may want to introduce
+                    // VolatileRead and VolatileWrite traits in the future.
+                    match dst.write(&src[start..end]) {
+                        Ok(n) => break Ok(n),
+                        Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                        Err(e) => break Err(Self::E::IOError(e)),
+                    }
+                }
+            },
+        )
+    }
+
+    fn write_all_to<F>(&self, addr: GuestAddress, dst: &mut F, count: usize) -> Result<(), Self::E>
+    where
+        F: Write,
+    {
+        let res = self.write_to(addr, dst, count)?;
+        if res != count {
+            return Err(Self::E::PartialBuffer {
+                expected: count,
+                completed: res,
+            });
+        }
+        Ok(())
+    }
+}
+
 impl GuestMemory for GuestMemoryMmap {
     type R = GuestRegionMmap;
 

--- a/src/refs.rs
+++ b/src/refs.rs
@@ -1,0 +1,115 @@
+//! This module provides two abstractions that allow borrowing a `GuestMemory` locations, instead
+//! of looking them up each time. `Ref` does that for a single `T: ByteValued` object, whereas
+//! `ArrayRef` is essentially (as the name suggests) an array of `Ref`s. All accesses done
+//! through these objects are inherently aligned.
+
+use std::marker::PhantomData;
+use std::mem::size_of;
+use std::ptr;
+
+use crate::access::{AutoBytes, HostRegion};
+use crate::ByteValued;
+use crate::GuestMemoryError;
+
+/// Alias for the result of operations defined in this module.
+pub type Result<T> = std::result::Result<T, GuestMemoryError>;
+
+/// Represents a `T: ByteValued` located in guest memory.
+#[derive(Debug)]
+pub struct Ref<'a, T: ByteValued> {
+    addr: *mut u8,
+    phantom: PhantomData<&'a T>,
+}
+
+impl<T: ByteValued> Ref<'_, T> {
+    /// Create a new `Ref` object.
+    ///
+    /// # Safety
+    ///
+    /// `addr` must be properly aligned with respect to `T` and valid for reads/writes.
+    pub unsafe fn new(addr: *mut u8) -> Self {
+        Ref {
+            addr,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Return the inner pointer to host memory.
+    pub fn as_ptr(&self) -> *mut T {
+        self.addr as *mut T
+    }
+
+    /// Read the value of the associated object.
+    pub fn read(&self) -> T {
+        // Safe because `addr` is valid for reads and properly aligned.
+        unsafe { ptr::read_volatile(self.as_ptr()) }
+    }
+
+    /// Write a new value to the associated object.
+    pub fn write(&self, value: T) {
+        // Safe because `addr` is valid for writes and properly aligned.
+        unsafe { ptr::write_volatile(self.as_ptr(), value) }
+    }
+}
+
+/// Represents an array of `T: ByteValued` located in guest memory.
+#[derive(Debug)]
+pub struct ArrayRef<'a, T: ByteValued> {
+    addr: *mut u8,
+    len: usize,
+    phantom: PhantomData<&'a T>,
+}
+
+impl<'a, T: ByteValued> ArrayRef<'a, T> {
+    /// Create a new `ArrayRef` object.
+    ///
+    /// # Safety
+    ///
+    /// `addr` must be properly aligned with respect to `T` and valid for reads/writes for the
+    /// entire length of the array.
+    pub unsafe fn new(addr: *mut u8, len: usize) -> Self {
+        ArrayRef {
+            addr,
+            len,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Return the inner pointer to host memory.
+    pub fn as_ptr(&self) -> *mut T {
+        self.addr as *mut T
+    }
+
+    /// Return the number of elements in the array.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Return the `Ref` object for the specified `index`.
+    pub fn at(&self, index: usize) -> Result<Ref<'a, T>> {
+        if index >= self.len {
+            return Err(GuestMemoryError::InvalidAccess);
+        }
+
+        // We don't have to check for overflow because the index is within bounds.
+        let ref_addr = self.addr as usize + (index * size_of::<T>());
+
+        // Safe because `T` is `ByteValued`, and the address is properly aligned and
+        // within array bounds.
+        unsafe { Ok(Ref::new(ref_addr as *mut u8)) }
+    }
+}
+
+// `ArrayRef<u8>` can be seen as an opaque region of host process memory.
+impl HostRegion for ArrayRef<'_, u8> {
+    fn as_ptr(&self) -> *mut u8 {
+        ArrayRef::as_ptr(self)
+    }
+    fn len(&self) -> usize {
+        ArrayRef::len(self)
+    }
+}
+
+// This provides an automatic `Bytes` implementation for `ArrayRef<u8>` based on
+// `CheckAccess<usize>` (itself automatically implemented because `ArrayRef<u8>: HostRegion`.
+impl AutoBytes<usize> for ArrayRef<'_, u8> {}

--- a/src/volatile_memory.rs
+++ b/src/volatile_memory.rs
@@ -36,7 +36,7 @@ use std::result;
 use std::slice::{from_raw_parts, from_raw_parts_mut};
 use std::usize;
 
-use crate::{ByteValued, Bytes};
+use crate::{ArrayRef, ByteValued, Bytes, Ref};
 
 /// `VolatileMemory` related errors.
 #[allow(missing_docs)]
@@ -751,6 +751,14 @@ impl Bytes<usize> for VolatileSlice<'_> {
             dst.write_all(src).map_err(Error::IOError)?;
         }
         Ok(())
+    }
+
+    fn ref_at<T: ByteValued>(&self, _addr: usize) -> Result<Ref<T>> {
+        unimplemented!()
+    }
+
+    fn array_ref_at<T: ByteValued>(&self, _addr: usize, _len: usize) -> Result<ArrayRef<T>> {
+        unimplemented!()
     }
 }
 


### PR DESCRIPTION
Hi! This RFC proposes changes to `vm-memory` with the purpose of improving performance, avoiding duplication of logic that accesses memory contents, and simplifying/eliminating some of the crate contents. For now, the PR mostly proposes changes and several alternative abstractions; more commits that remove existing things will follow.

The proposal is based on the simplifying assumption that guest memory regions adjacent in terms of guest physical addresses can be contiguous in process virtual memory as well. This mean we can aggregate multiple neighbouring regions into a single continuous range, which removes the need to  implement special handling for cross-region accesses. The PR adds a `GuestRange` helper object and checks that guest regions provided to `GuestMemoryMmap` constructors satisfy the condition (otherwise an error is generated). There's no logic yet which helps create such memory objects (will be added later; there's an example in the benches code that uses a simplistic approach, and others are possible). Also, for use cases that do not require `GuestMemoryMmap` objects with adjacent regions to be created, folks wanting to try things out can simply `[patch]` their `vm-memory` dependency in `Cargo.toml` with commit f2f4db7a to see if there's any noticeable difference.

The PR also introduces an `access` module, which leverages the previous assumption to provide a single `Bytes` implementation for all entities which expose the interface, based on much simpler helper traits. It also proposes `ArrayRef` and `Ref` as simpler alternatives to `VolatileRef`, `VolatileArrayRef`, and `VolatileSlice`. Finally, it also adds `Aligned` and atomic access logic based on parts of #104. I think the aligned part is useful, but at the same time it's orthogonal to everything else and can be dropped if ppl don't think it brings any value. More details are available in commit messages and individual comments.