### PR TITLE
Add methods for atomic access to Bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,23 @@
 # Changelog 
 ## [Unreleased]
 
-### Fixed
-- [[#106]](https://github.com/rust-vmm/vm-memory/issues/106): Asserts trigger
-  on zero-length access.  
-
 ### Added
+
 - [[#109]](https://github.com/rust-vmm/vm-memory/pull/109): Added `build_raw` to
   `MmapRegion` which can be used to operate on externally created mappings.
 - [[#101]](https://github.com/rust-vmm/vm-memory/pull/101): Added `check_range` for
   GuestMemory which could be used to validate a range of guest memory.
+- [[#115]](https://github.com/rust-vmm/vm-memory/pull/115): Add methods for atomic
+  access to `Bytes`.
+
+### Fixed
+
+- [[#106]](https://github.com/rust-vmm/vm-memory/issues/106): Asserts trigger
+  on zero-length access.  
+
+### Removed
+
+- `integer-atomics` is no longer a distinct feature of the crate.
 
 ## [v0.2.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ autobenches = false
 
 [features]
 default = []
-integer-atomics = []
 backend-mmap = []
 backend-atomic = ["arc-swap"]
 

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 84.8,
+  "coverage_score": 85.4,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap,backend-atomic"
 }

--- a/src/atomic_integer.rs
+++ b/src/atomic_integer.rs
@@ -1,0 +1,90 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+use std::sync::atomic::Ordering;
+
+/// Objects that implement this trait must consist exclusively of atomic types
+/// from [`std::sync::atomic`](https://doc.rust-lang.org/std/sync/atomic/), except for
+/// [`AtomicPtr<T>`](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicPtr.html) and
+/// [`AtomicBool`](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicBool.html).
+pub unsafe trait AtomicInteger: Sync + Send {
+    /// The raw value type associated with the atomic integer (i.e. `u16` for `AtomicU16`).
+    type V;
+
+    /// Create a new instance of `Self`.
+    fn new(v: Self::V) -> Self;
+
+    /// Loads a value from the atomic integer.
+    fn load(&self, order: Ordering) -> Self::V;
+
+    /// Stores a value into the atomic integer.
+    fn store(&self, val: Self::V, order: Ordering);
+}
+
+macro_rules! impl_atomic_integer_ops {
+    ($T:path, $V:ty) => {
+        unsafe impl AtomicInteger for $T {
+            type V = $V;
+
+            fn new(v: Self::V) -> Self {
+                Self::new(v)
+            }
+
+            fn load(&self, order: Ordering) -> Self::V {
+                self.load(order)
+            }
+
+            fn store(&self, val: Self::V, order: Ordering) {
+                self.store(val, order)
+            }
+        }
+    };
+}
+
+// TODO: Detect availability using #[cfg(target_has_atomic) when it is stabilized.
+// Right now we essentially assume we're running on either x86 or Arm (32 or 64 bit). AFAIK,
+// Rust starts using additional synchronization primitives to implement atomics when they're
+// not natively available, and that doesn't interact safely with how we cast pointers to
+// atomic value references. We should be wary of this when looking at a broader range of
+// platforms.
+
+impl_atomic_integer_ops!(std::sync::atomic::AtomicI8, i8);
+impl_atomic_integer_ops!(std::sync::atomic::AtomicI16, i16);
+impl_atomic_integer_ops!(std::sync::atomic::AtomicI32, i32);
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+impl_atomic_integer_ops!(std::sync::atomic::AtomicI64, i64);
+
+impl_atomic_integer_ops!(std::sync::atomic::AtomicU8, u8);
+impl_atomic_integer_ops!(std::sync::atomic::AtomicU16, u16);
+impl_atomic_integer_ops!(std::sync::atomic::AtomicU32, u32);
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+impl_atomic_integer_ops!(std::sync::atomic::AtomicU64, u64);
+
+impl_atomic_integer_ops!(std::sync::atomic::AtomicIsize, isize);
+impl_atomic_integer_ops!(std::sync::atomic::AtomicUsize, usize);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::fmt::Debug;
+    use std::sync::atomic::AtomicU32;
+
+    fn check_atomic_integer_ops<A: AtomicInteger>()
+    where
+        A::V: Copy + Debug + From<u8> + PartialEq,
+    {
+        let v = A::V::from(0);
+        let a = A::new(v);
+        assert_eq!(a.load(Ordering::Relaxed), v);
+
+        let v2 = A::V::from(100);
+        a.store(v2, Ordering::Relaxed);
+        assert_eq!(a.load(Ordering::Relaxed), v2);
+    }
+
+    #[test]
+    fn test_atomic_integer_ops() {
+        check_atomic_integer_ops::<AtomicU32>()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,14 @@
 pub mod address;
 pub use address::{Address, AddressValue};
 
+#[cfg(feature = "backend-atomic")]
+pub mod atomic;
+#[cfg(feature = "backend-atomic")]
+pub use atomic::{GuestMemoryAtomic, GuestMemoryLoadGuard};
+
+mod atomic_integer;
+pub use atomic_integer::AtomicInteger;
+
 pub mod bytes;
 pub use bytes::{ByteValued, Bytes};
 
@@ -46,13 +54,8 @@ pub mod mmap;
 #[cfg(feature = "backend-mmap")]
 pub use mmap::{Error, GuestMemoryMmap, GuestRegionMmap, MmapRegion};
 
-#[cfg(feature = "backend-atomic")]
-pub mod atomic;
-#[cfg(feature = "backend-atomic")]
-pub use atomic::{GuestMemoryAtomic, GuestMemoryLoadGuard};
-
 pub mod volatile_memory;
 pub use volatile_memory::{
-    AtomicInteger, Error as VolatileMemoryError, Result as VolatileMemoryResult, VolatileArrayRef,
-    VolatileMemory, VolatileRef, VolatileSlice,
+    Error as VolatileMemoryError, Result as VolatileMemoryResult, VolatileArrayRef, VolatileMemory,
+    VolatileRef, VolatileSlice,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ mod atomic_integer;
 pub use atomic_integer::AtomicInteger;
 
 pub mod bytes;
-pub use bytes::{ByteValued, Bytes};
+pub use bytes::{AtomicAccess, ByteValued, Bytes};
 
 pub mod endian;
 pub use endian::{Be16, Be32, Be64, BeSize, Le16, Le32, Le64, LeSize};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,6 @@ pub use atomic::{GuestMemoryAtomic, GuestMemoryLoadGuard};
 
 pub mod volatile_memory;
 pub use volatile_memory::{
-    AtomicValued, Error as VolatileMemoryError, Result as VolatileMemoryResult, VolatileArrayRef,
+    AtomicInteger, Error as VolatileMemoryError, Result as VolatileMemoryResult, VolatileArrayRef,
     VolatileMemory, VolatileRef, VolatileSlice,
 };

--- a/src/volatile_memory.rs
+++ b/src/volatile_memory.rs
@@ -36,6 +36,7 @@ use std::result;
 use std::slice::{from_raw_parts, from_raw_parts_mut};
 use std::usize;
 
+use crate::atomic_integer::AtomicInteger;
 use crate::{ByteValued, Bytes};
 
 use copy_slice_impl::copy_slice;
@@ -118,35 +119,6 @@ pub fn compute_offset(base: usize, offset: usize) -> Result<usize> {
         Some(m) => Ok(m),
     }
 }
-
-/// Types that can be read safely from a [`VolatileSlice`](struct.VolatileSlice.html).
-///
-/// Objects that implement this trait must consist exclusively of atomic types
-/// from [`std::sync::atomic`](https://doc.rust-lang.org/std/sync/atomic/), except for
-/// [`AtomicPtr<T>`](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicPtr.html).
-pub unsafe trait AtomicInteger: Sync + Send {}
-
-// TODO: Detect availability using #[cfg(target_has_atomic) when it is stabilized.
-// Right now we essentially assume we're running on either x86 or Arm (32 or 64 bit). AFAIK,
-// Rust starts using additional synchronization primitives to implement atomics when they're
-// not natively available, and that doesn't interact safely with how we cast pointers to
-// atomic value references. We should be wary of this when looking at a broader range of
-// platforms.
-
-unsafe impl AtomicInteger for std::sync::atomic::AtomicI8 {}
-unsafe impl AtomicInteger for std::sync::atomic::AtomicI16 {}
-unsafe impl AtomicInteger for std::sync::atomic::AtomicI32 {}
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-unsafe impl AtomicInteger for std::sync::atomic::AtomicI64 {}
-
-unsafe impl AtomicInteger for std::sync::atomic::AtomicU8 {}
-unsafe impl AtomicInteger for std::sync::atomic::AtomicU16 {}
-unsafe impl AtomicInteger for std::sync::atomic::AtomicU32 {}
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-unsafe impl AtomicInteger for std::sync::atomic::AtomicU64 {}
-
-unsafe impl AtomicInteger for std::sync::atomic::AtomicIsize {}
-unsafe impl AtomicInteger for std::sync::atomic::AtomicUsize {}
 
 /// Types that support raw volatile access to their data.
 pub trait VolatileMemory {

--- a/src/volatile_memory.rs
+++ b/src/volatile_memory.rs
@@ -124,29 +124,29 @@ pub fn compute_offset(base: usize, offset: usize) -> Result<usize> {
 /// Objects that implement this trait must consist exclusively of atomic types
 /// from [`std::sync::atomic`](https://doc.rust-lang.org/std/sync/atomic/), except for
 /// [`AtomicPtr<T>`](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicPtr.html).
-pub unsafe trait AtomicValued: Sync + Send {}
+pub unsafe trait AtomicInteger: Sync + Send {}
 
-// also conditionalize on #[cfg(target_has_atomic) when it is stabilized
-#[cfg(feature = "integer-atomics")]
-unsafe impl AtomicValued for std::sync::atomic::AtomicBool {}
-#[cfg(feature = "integer-atomics")]
-unsafe impl AtomicValued for std::sync::atomic::AtomicI8 {}
-#[cfg(feature = "integer-atomics")]
-unsafe impl AtomicValued for std::sync::atomic::AtomicI16 {}
-#[cfg(feature = "integer-atomics")]
-unsafe impl AtomicValued for std::sync::atomic::AtomicI32 {}
-#[cfg(feature = "integer-atomics")]
-unsafe impl AtomicValued for std::sync::atomic::AtomicI64 {}
-unsafe impl AtomicValued for std::sync::atomic::AtomicIsize {}
-#[cfg(feature = "integer-atomics")]
-unsafe impl AtomicValued for std::sync::atomic::AtomicU8 {}
-#[cfg(feature = "integer-atomics")]
-unsafe impl AtomicValued for std::sync::atomic::AtomicU16 {}
-#[cfg(feature = "integer-atomics")]
-unsafe impl AtomicValued for std::sync::atomic::AtomicU32 {}
-#[cfg(feature = "integer-atomics")]
-unsafe impl AtomicValued for std::sync::atomic::AtomicU64 {}
-unsafe impl AtomicValued for std::sync::atomic::AtomicUsize {}
+// TODO: Detect availability using #[cfg(target_has_atomic) when it is stabilized.
+// Right now we essentially assume we're running on either x86 or Arm (32 or 64 bit). AFAIK,
+// Rust starts using additional synchronization primitives to implement atomics when they're
+// not natively available, and that doesn't interact safely with how we cast pointers to
+// atomic value references. We should be wary of this when looking at a broader range of
+// platforms.
+
+unsafe impl AtomicInteger for std::sync::atomic::AtomicI8 {}
+unsafe impl AtomicInteger for std::sync::atomic::AtomicI16 {}
+unsafe impl AtomicInteger for std::sync::atomic::AtomicI32 {}
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+unsafe impl AtomicInteger for std::sync::atomic::AtomicI64 {}
+
+unsafe impl AtomicInteger for std::sync::atomic::AtomicU8 {}
+unsafe impl AtomicInteger for std::sync::atomic::AtomicU16 {}
+unsafe impl AtomicInteger for std::sync::atomic::AtomicU32 {}
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+unsafe impl AtomicInteger for std::sync::atomic::AtomicU64 {}
+
+unsafe impl AtomicInteger for std::sync::atomic::AtomicIsize {}
+unsafe impl AtomicInteger for std::sync::atomic::AtomicUsize {}
 
 /// Types that support raw volatile access to their data.
 pub trait VolatileMemory {
@@ -235,7 +235,7 @@ pub trait VolatileMemory {
     ///
     /// If the resulting pointer is not aligned, this method will return an
     /// [`Error`](enum.Error.html).
-    fn get_atomic_ref<T: AtomicValued>(&self, offset: usize) -> Result<&T> {
+    fn get_atomic_ref<T: AtomicInteger>(&self, offset: usize) -> Result<&T> {
         let slice = self.get_slice(offset, size_of::<T>())?;
         slice.check_alignment(align_of::<T>())?;
 


### PR DESCRIPTION
This PR adds the `load` and `store` methods to the `Bytes` interface, which can be used to perform atomic accesses based on a specified `Ordering` argument. It's a simplified variant of #104, which does not include the abstractions for aligned accesses.