### PR TITLE
volatile_memory: Only use volatile copy for small objects

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 85.4,
+  "coverage_score": 85.5,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap,backend-atomic"
 }

--- a/src/volatile_memory.rs
+++ b/src/volatile_memory.rs
@@ -1082,7 +1082,7 @@ mod copy_slice_impl {
         }
     }
 
-    pub(super) fn copy_slice(dst: &mut [u8], src: &[u8]) -> usize {
+    fn copy_slice_volatile(dst: &mut [u8], src: &[u8]) -> usize {
         let total = min(src.len(), dst.len());
         let mut left = total;
 
@@ -1107,6 +1107,17 @@ mod copy_slice_impl {
         copy_aligned_slice(4);
         copy_aligned_slice(2);
         copy_aligned_slice(1);
+
+        total
+    }
+
+    pub(super) fn copy_slice(dst: &mut [u8], src: &[u8]) -> usize {
+        let total = min(src.len(), dst.len());
+        if total <= size_of::<usize>() {
+            copy_slice_volatile(dst, src);
+        } else {
+            dst[..total].copy_from_slice(&src[..total]);
+        }
 
         total
     }


### PR DESCRIPTION
Where small objects are those objects that are less then the native data
width for the platform. This ensure that volatile and alignment safe
read/writes are used when updating structures that are sensitive to this
such as virtio devices where the spec requires writes to be atomic.

Fixes: cloud-hypervisor/cloud-hypervisor#1258
Fixes: #100

Signed-off-by: Rob Bradford <robert.bradford@intel.com>