### PR TITLE
Add is_hugetlbfs() to GuestMemoryRegion

### DIFF
--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -289,6 +289,26 @@ pub trait GuestMemoryRegion: Bytes<MemoryRegionAddress, E = Error> {
     fn as_volatile_slice(&self) -> Result<volatile_memory::VolatileSlice> {
         self.get_slice(MemoryRegionAddress(0), self.len() as usize)
     }
+
+    /// Show if the region is based on the `HugeTLBFS`.
+    /// Returns Some(true) if the region is backed by hugetlbfs.
+    /// None represents that no information is available.
+    ///
+    /// # Examples (uses the `backend-mmap` feature)
+    ///
+    /// ```
+    /// # #[cfg(feature = "backend-mmap")]
+    /// # {
+    /// #   use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap, GuestRegionMmap};
+    ///     let addr = GuestAddress(0x1000);
+    ///     let mem = GuestMemoryMmap::from_ranges(&[(addr, 0x1000)]).unwrap();
+    ///     let r = mem.find_region(addr).unwrap();
+    ///     assert_eq!(r.is_hugetlbfs(), None);
+    /// # }
+    /// ```
+    fn is_hugetlbfs(&self) -> Option<bool> {
+        None
+    }
 }
 
 /// `GuestAddressSpace` provides a way to retrieve a `GuestMemory` object.
@@ -1198,5 +1218,14 @@ mod tests {
         let bad_addr = addr.unchecked_add(0x1000);
 
         crate::bytes::tests::check_atomic_accesses(mem, addr, bad_addr);
+    }
+
+    #[cfg(feature = "backend-mmap")]
+    #[test]
+    fn test_guest_memory_mmap_is_hugetlbfs() {
+        let addr = GuestAddress(0x1000);
+        let mem = GuestMemoryMmap::from_ranges(&[(addr, 0x1000)]).unwrap();
+        let r = mem.find_region(addr).unwrap();
+        assert_eq!(r.is_hugetlbfs(), None);
     }
 }

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -456,6 +456,10 @@ impl GuestMemoryRegion for GuestRegionMmap {
         let slice = self.mapping.get_slice(offset.raw_value() as usize, count)?;
         Ok(slice)
     }
+
+    fn is_hugetlbfs(&self) -> Option<bool> {
+        self.mapping.is_hugetlbfs()
+    }
 }
 
 /// [`GuestMemory`](trait.GuestMemory.html) implementation that mmaps the guest's memory

--- a/src/mmap_windows.rs
+++ b/src/mmap_windows.rs
@@ -175,6 +175,11 @@ impl MmapRegion {
     pub fn file_offset(&self) -> Option<&FileOffset> {
         self.file_offset.as_ref()
     }
+
+    /// This information is not available on Windows platforms.
+    pub fn is_hugetlbfs(&self) -> Option<bool> {
+        None
+    }
 }
 
 impl AsSlice for MmapRegion {


### PR DESCRIPTION
 Virtio-balloon can release the unused host memory to decrease the memory usage of the VMM.
 Release normal pages and hugetlbfs pages require different operations. (madvise MADV_DONTNEED and fallocate64 FALLOC_FL_PUNCH_HOLE)

This commit add Add is_hugetlbfs() to GuestMemoryRegion to help VMM decide if this is a hugetlbfs address or not.
