### PR TITLE
mmap.rs: Test the last address in test_checked_offset and test_check_…

### DIFF
--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -1443,6 +1443,12 @@ mod tests {
         );
         assert_eq!(guest_mem.checked_offset(start_addr2, 0xc00), None);
         assert_eq!(guest_mem.checked_offset(start_addr1, std::usize::MAX), None);
+
+        assert_eq!(guest_mem.checked_offset(start_addr1, 0x400), None);
+        assert_eq!(
+            guest_mem.checked_offset(start_addr1, 0x400 - 1),
+            Some(GuestAddress(0x400 - 1))
+        );
     }
 
     #[test]
@@ -1459,6 +1465,7 @@ mod tests {
 
         assert_eq!(guest_mem.check_range(start_addr1, 0x0), true);
         assert_eq!(guest_mem.check_range(start_addr1, 0x200), true);
+        assert_eq!(guest_mem.check_range(start_addr1, 0x400), true);
         assert_eq!(guest_mem.check_range(start_addr1, 0xa00), false);
         assert_eq!(guest_mem.check_range(start_addr2, 0x7ff), true);
         assert_eq!(guest_mem.check_range(start_addr2, 0x800), true);


### PR DESCRIPTION
…range

Met an issue that uses checked_offset with len to check if an address
and len is valid in cloud-hypervisor.
It will fail when len is the max size of the range.

This commit adds test code for the last address to test_checked_offset
and test_check_range to test and shows how to handle the last address
clearly.

Signed-off-by: Hui Zhu <teawater@antfin.com>