### PR TITLE
atomic, Cargo.toml: Update for arc-swap 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ backend-atomic = ["arc-swap"]
 
 [dependencies]
 libc = ">=0.2.39"
-arc-swap = { version = ">=0.4.5", optional = true }
+arc-swap = { version = ">=1.0.0", optional = true }
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = ">=0.3"

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -52,7 +52,7 @@ impl<M: GuestMemory> GuestMemoryAtomic<M> {
         Arc::new(map).into()
     }
 
-    fn load(&self) -> Guard<'static, Arc<M>> {
+    fn load(&self) -> Guard<Arc<M>> {
         self.inner.0.load()
     }
 
@@ -90,7 +90,7 @@ impl<M: GuestMemory> GuestAddressSpace for GuestMemoryAtomic<M> {
 /// access memory.
 #[derive(Debug)]
 pub struct GuestMemoryLoadGuard<M: GuestMemory> {
-    guard: Guard<'static, Arc<M>>,
+    guard: Guard<Arc<M>>,
 }
 
 impl<M: GuestMemory> GuestMemoryLoadGuard<M> {


### PR DESCRIPTION
Since there is no Cargo.lock file checked in any user of this crate will
use the latest version of arc-swap, now at 1.0.0, which has a slightly
changed API.

Update the dependency to 1.0.0 and port the guard logic to the new API.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>