### PR TITLE
v0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
-# Changelog 
+# Changelog
+
+## [v0.4.0]
+
+### Fixed
+
+- [[#100]](https://github.com/rust-vmm/vm-memory/issues/100): Performance
+  degradation after fixing [#95](https://github.com/rust-vmm/vm-memory/pull/95).
+- [[#122]](https://github.com/rust-vmm/vm-memory/pull/122): atomic,
+  Cargo.toml: Update for arc-swap 1.0.0.
 
 ## [v0.3.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vm-memory"
-version = "0.3.0"
+version = "0.4.0"
 description = "Safe abstractions for accessing the VM physical memory"
 keywords = ["memory"]
 authors = ["Liu Jiang <gerry@linux.alibaba.com>"]


### PR DESCRIPTION
v0.3.0 no longer compiles because of the v1.0.0 arc-swap dependency: https://buildkite.com/rust-vmm/vm-virtio-ci/builds/106#c06f43f3-0436-4219-aa32-fee31ccbcf2e