### PR TITLE
Add dirty bitmap tracking abstractions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 ## [Unreleased]
 
+### Added
+
+  - [[#140]](https://github.com/rust-vmm/vm-memory/issues/140): Add dirty bitmap tracking abstractions. 
+
 ### Deprecated 
 
   - [[#133]](https://github.com/rust-vmm/vm-memory/issues/8): Deprecate `GuestMemory::with_regions()`,
-   `GuestMemory::with_regions_mut()`, `GuestMemory::map_and_fold()`
+   `GuestMemory::with_regions_mut()`, `GuestMemory::map_and_fold()`.
 
 ## [v0.5.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ arc-swap = { version = ">=1.0.0", optional = true }
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = ">=0.3"
-features = ["errhandlingapi"]
+features = ["errhandlingapi", "sysinfoapi"]
 
 [dev-dependencies]
 criterion = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ autobenches = false
 
 [features]
 default = []
+backend-bitmap = []
 backend-mmap = []
 backend-atomic = ["arc-swap"]
 

--- a/benches/guest_memory.rs
+++ b/benches/guest_memory.rs
@@ -4,6 +4,8 @@
 #![cfg(feature = "backend-mmap")]
 
 pub use criterion::{black_box, Criterion};
+
+use vm_memory::bitmap::Bitmap;
 use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap};
 
 const REGION_SIZE: usize = 0x10_0000;
@@ -13,7 +15,10 @@ pub fn benchmark_for_guest_memory(c: &mut Criterion) {
     benchmark_find_region(c);
 }
 
-fn find_region(mem: &GuestMemoryMmap) {
+fn find_region<B>(mem: &GuestMemoryMmap<B>)
+where
+    B: Bitmap + 'static,
+{
     for i in 0..REGIONS_COUNT {
         let _ = mem
             .find_region(black_box(GuestAddress(i * REGION_SIZE as u64)))

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -17,7 +17,7 @@ use volatile::benchmark_for_volatile;
 #[cfg(feature = "backend-mmap")]
 // Use this function with caution. It does not check against overflows
 // and `GuestMemoryMmap::from_ranges` errors.
-fn create_guest_memory_mmap(size: usize, count: u64) -> GuestMemoryMmap {
+fn create_guest_memory_mmap(size: usize, count: u64) -> GuestMemoryMmap<()> {
     let mut regions: Vec<(GuestAddress, usize)> = Vec::new();
     for i in 0..count {
         regions.push((GuestAddress(i * size as u64), size));

--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
   "coverage_score": 85.2,
   "exclude_path": "mmap_windows.rs",
-  "crate_features": "backend-mmap,backend-atomic"
+  "crate_features": "backend-mmap,backend-atomic,backend-bitmap"
 }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 85.4,
+  "coverage_score": 87.5,
   "exclude_path": "mmap_windows.rs",
-  "crate_features": "backend-mmap,backend-atomic"
+  "crate_features": "backend-mmap,backend-atomic,backend-bitmap"
 }

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -142,11 +142,10 @@ impl<M: GuestMemory> GuestMemoryExclusiveGuard<'_, M> {
 #[cfg(feature = "backend-mmap")]
 mod tests {
     use super::*;
-    use crate::{
-        GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion, GuestRegionMmap, GuestUsize,
-        MmapRegion,
-    };
+    use crate::{GuestAddress, GuestMemory, GuestMemoryRegion, GuestUsize, MmapRegion};
 
+    type GuestMemoryMmap = crate::GuestMemoryMmap<()>;
+    type GuestRegionMmap = crate::GuestRegionMmap<()>;
     type GuestMemoryMmapAtomic = GuestMemoryAtomic<GuestMemoryMmap>;
 
     #[test]

--- a/src/bitmap/backend/atomic_bitmap.rs
+++ b/src/bitmap/backend/atomic_bitmap.rs
@@ -147,10 +147,12 @@ impl NewBitmap for AtomicBitmap {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    use crate::bitmap::tests::test_bitmap;
+
     #[test]
     fn test_bitmap_basic() {
-        use super::AtomicBitmap;
-
         // Test that bitmap size is properly rounded up.
         let a = AtomicBitmap::new(1025, 128);
         assert_eq!(a.len(), 9);
@@ -175,7 +177,6 @@ mod tests {
 
     #[test]
     fn test_bitmap_out_of_range() {
-        use super::AtomicBitmap;
         let b = AtomicBitmap::new(1024, 1);
         // Set a partial range that goes beyond the end of the bitmap
         b.set_addr_range(768, 512);
@@ -183,5 +184,11 @@ mod tests {
         // The bitmap is never set beyond its end.
         assert!(!b.is_addr_set(1024));
         assert!(!b.is_addr_set(1152));
+    }
+
+    #[test]
+    fn test_bitmap_impl() {
+        let b = AtomicBitmap::new(0x2000, 128);
+        test_bitmap(&b);
     }
 }

--- a/src/bitmap/backend/atomic_bitmap.rs
+++ b/src/bitmap/backend/atomic_bitmap.rs
@@ -1,0 +1,187 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+//! Bitmap backend implementation based on atomic integers.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::bitmap::{Bitmap, RefSlice, WithBitmapSlice};
+
+#[cfg(feature = "backend-mmap")]
+use crate::mmap::NewBitmap;
+
+/// `AtomicBitmap` implements a simple bit map on the page level with test and set operations.
+/// It is page-size aware, so it converts addresses to page numbers before setting or clearing
+/// the bits.
+#[derive(Debug)]
+pub struct AtomicBitmap {
+    map: Vec<AtomicU64>,
+    size: usize,
+    page_size: usize,
+}
+
+#[allow(clippy::len_without_is_empty)]
+impl AtomicBitmap {
+    /// Create a new bitmap of `byte_size`, with one bit per page. This is effectively
+    /// rounded up, and we get a new vector of the next multiple of 64 bigger than `bit_size`.
+    pub fn new(byte_size: usize, page_size: usize) -> Self {
+        let mut num_pages = byte_size / page_size;
+        if byte_size % page_size > 0 {
+            num_pages += 1;
+        }
+
+        // Adding one entry element more just in case `num_pages` is not a multiple of `64`.
+        let map_size = num_pages / 64 + 1;
+        let map: Vec<AtomicU64> = (0..map_size).map(|_| AtomicU64::new(0)).collect();
+
+        AtomicBitmap {
+            map,
+            size: num_pages,
+            page_size,
+        }
+    }
+
+    /// Is bit `n` set? Bits outside the range of the bitmap are always unset.
+    pub fn is_bit_set(&self, index: usize) -> bool {
+        if index < self.size {
+            (self.map[index >> 6].load(Ordering::Acquire) & (1 << (index & 63))) != 0
+        } else {
+            // Out-of-range bits are always unset.
+            false
+        }
+    }
+
+    /// Is the bit corresponding to address `addr` set?
+    pub fn is_addr_set(&self, addr: usize) -> bool {
+        self.is_bit_set(addr / self.page_size)
+    }
+
+    /// Set a range of `len` bytes starting at `start_addr`. The first bit set in the bitmap
+    /// is for the page corresponding to `start_addr`, and the last bit that we set corresponds
+    /// to address `start_addr + len - 1`.
+    pub fn set_addr_range(&self, start_addr: usize, len: usize) {
+        // Return early in the unlikely event that `len == 0` so the `len - 1` computation
+        // below does not underflow.
+        if len == 0 {
+            return;
+        }
+
+        let first_bit = start_addr / self.page_size;
+        // Handle input ranges where `start_addr + len - 1` would otherwise overflow an `usize`
+        // by ignoring pages at invalid addresses.
+        let last_bit = start_addr.saturating_add(len - 1) / self.page_size;
+        for n in first_bit..=last_bit {
+            if n >= self.size {
+                // Attempts to set bits beyond the end of the bitmap are simply ignored.
+                break;
+            }
+            self.map[n >> 6].fetch_or(1 << (n & 63), Ordering::SeqCst);
+        }
+    }
+
+    /// Get the length of the bitmap in bits (i.e. in how many pages it can represent).
+    pub fn len(&self) -> usize {
+        self.size
+    }
+
+    /// Reset all bitmap bits to 0.
+    pub fn reset(&self) {
+        for it in self.map.iter() {
+            it.store(0, Ordering::Release);
+        }
+    }
+}
+
+impl Clone for AtomicBitmap {
+    fn clone(&self) -> Self {
+        let map = self
+            .map
+            .iter()
+            .map(|i| i.load(Ordering::Acquire))
+            .map(AtomicU64::new)
+            .collect();
+        AtomicBitmap {
+            map,
+            size: self.size,
+            page_size: self.page_size,
+        }
+    }
+}
+
+impl<'a> WithBitmapSlice<'a> for AtomicBitmap {
+    type S = RefSlice<'a, Self>;
+}
+
+impl Bitmap for AtomicBitmap {
+    fn mark_dirty(&self, offset: usize, len: usize) {
+        self.set_addr_range(offset, len)
+    }
+
+    fn dirty_at(&self, offset: usize) -> bool {
+        self.is_addr_set(offset)
+    }
+
+    fn slice_at(&self, offset: usize) -> <Self as WithBitmapSlice>::S {
+        RefSlice::new(self, offset)
+    }
+}
+
+impl Default for AtomicBitmap {
+    fn default() -> Self {
+        AtomicBitmap::new(0, 0x1000)
+    }
+}
+
+#[cfg(feature = "backend-mmap")]
+impl NewBitmap for AtomicBitmap {
+    fn with_len(len: usize) -> Self {
+        use std::convert::TryFrom;
+
+        // There's no unsafe potential in calling this function.
+        let page_size = unsafe { libc::sysconf(libc::_SC_PAGE_SIZE) };
+        // The `unwrap` is safe to use because the above call should always succeed on the
+        // supported platforms, and the size of a page will always fit within a `usize`.
+        AtomicBitmap::new(len, usize::try_from(page_size).unwrap())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_bitmap_basic() {
+        use super::AtomicBitmap;
+
+        // Test that bitmap size is properly rounded up.
+        let a = AtomicBitmap::new(1025, 128);
+        assert_eq!(a.len(), 9);
+
+        let b = AtomicBitmap::new(1024, 128);
+        assert_eq!(b.len(), 8);
+        b.set_addr_range(128, 129);
+        assert!(!b.is_addr_set(0));
+        assert!(b.is_addr_set(128));
+        assert!(b.is_addr_set(256));
+        assert!(!b.is_addr_set(384));
+
+        let copy_b = b.clone();
+        assert!(copy_b.is_addr_set(256));
+        assert!(!copy_b.is_addr_set(384));
+
+        b.reset();
+        assert!(!b.is_addr_set(128));
+        assert!(!b.is_addr_set(256));
+        assert!(!b.is_addr_set(384));
+    }
+
+    #[test]
+    fn test_bitmap_out_of_range() {
+        use super::AtomicBitmap;
+        let b = AtomicBitmap::new(1024, 1);
+        // Set a partial range that goes beyond the end of the bitmap
+        b.set_addr_range(768, 512);
+        assert!(b.is_addr_set(768));
+        // The bitmap is never set beyond its end.
+        assert!(!b.is_addr_set(1024));
+        assert!(!b.is_addr_set(1152));
+    }
+}

--- a/src/bitmap/backend/atomic_bitmap.rs
+++ b/src/bitmap/backend/atomic_bitmap.rs
@@ -84,6 +84,14 @@ impl AtomicBitmap {
         self.size
     }
 
+    /// Atomically get and reset the dirty page bitmap.
+    pub fn get_and_reset(&self) -> Vec<u64> {
+        self.map
+            .iter()
+            .map(|u| u.fetch_and(0, Ordering::SeqCst))
+            .collect()
+    }
+
     /// Reset all bitmap bits to 0.
     pub fn reset(&self) {
         for it in self.map.iter() {
@@ -193,6 +201,16 @@ mod tests {
         assert!(!b.is_addr_set(128));
         assert!(!b.is_addr_set(256));
         assert!(!b.is_addr_set(384));
+
+        b.set_addr_range(128, 129);
+        let v = b.get_and_reset();
+
+        assert!(!b.is_addr_set(128));
+        assert!(!b.is_addr_set(256));
+        assert!(!b.is_addr_set(384));
+
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0], 0b110);
     }
 
     #[test]

--- a/src/bitmap/backend/mod.rs
+++ b/src/bitmap/backend/mod.rs
@@ -1,0 +1,6 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+mod ref_slice;
+
+pub use ref_slice::RefSlice;

--- a/src/bitmap/backend/mod.rs
+++ b/src/bitmap/backend/mod.rs
@@ -1,6 +1,8 @@
 // Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
+mod atomic_bitmap;
 mod ref_slice;
 
+pub use atomic_bitmap::AtomicBitmap;
 pub use ref_slice::RefSlice;

--- a/src/bitmap/backend/ref_slice.rs
+++ b/src/bitmap/backend/ref_slice.rs
@@ -1,0 +1,74 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+//! Contains a generic implementation of `BitmapSlice`.
+
+use std::fmt::{self, Debug};
+
+use crate::bitmap::{Bitmap, BitmapSlice, WithBitmapSlice};
+
+/// Represents a slice into a `Bitmap` object, starting at `base_offset`.
+pub struct RefSlice<'a, B> {
+    inner: &'a B,
+    base_offset: usize,
+}
+
+impl<'a, B: Bitmap + 'a> RefSlice<'a, B> {
+    /// Create a new `BitmapSlice`, starting at the specified `offset`.
+    pub fn new(bitmap: &'a B, offset: usize) -> Self {
+        RefSlice {
+            inner: bitmap,
+            base_offset: offset,
+        }
+    }
+}
+
+impl<'a, B: Bitmap> WithBitmapSlice<'a> for RefSlice<'_, B> {
+    type S = Self;
+}
+
+impl<B: Bitmap> BitmapSlice for RefSlice<'_, B> {}
+
+impl<'a, B: Bitmap> Bitmap for RefSlice<'a, B> {
+    /// Mark the memory range specified by the given `offset` (relative to the base offset of
+    /// the slice) and `len` as dirtied.
+    fn mark_dirty(&self, offset: usize, len: usize) {
+        // The `Bitmap` operations are supposed to accompany guest memory accesses defined by the
+        // same parameters (i.e. offset & length), so we use simple wrapping arithmetic instead of
+        // performing additional checks. If an overflow would occur, we simply end up marking some
+        // other region as dirty (which is just a false positive) instead of a region that could
+        // not have been accessed to begin with.
+        self.inner
+            .mark_dirty(self.base_offset.wrapping_add(offset), len)
+    }
+
+    fn dirty_at(&self, offset: usize) -> bool {
+        self.inner.dirty_at(self.base_offset.wrapping_add(offset))
+    }
+
+    /// Create a new `BitmapSlice` starting from the specified `offset` into the current slice.
+    fn slice_at(&self, offset: usize) -> Self {
+        RefSlice {
+            inner: self.inner,
+            base_offset: self.base_offset.wrapping_add(offset),
+        }
+    }
+}
+
+impl<'a, B> Clone for RefSlice<'a, B> {
+    fn clone(&self) -> Self {
+        RefSlice {
+            inner: self.inner,
+            base_offset: self.base_offset,
+        }
+    }
+}
+
+impl<'a, B> Copy for RefSlice<'a, B> {}
+
+impl<'a, B> Debug for RefSlice<'a, B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Dummy impl for now.
+        write!(f, "(bitmap slice)")
+    }
+}

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -6,9 +6,15 @@
 //! `GuestMemoryRegion` object, and the resulting bitmaps can then be aggregated to build the
 //! global view for an entire `GuestMemory` object.
 
+#[cfg(any(test, feature = "backend-bitmap"))]
+mod backend;
+
 use std::fmt::Debug;
 
 use crate::{GuestMemory, GuestMemoryRegion};
+
+#[cfg(any(test, feature = "backend-bitmap"))]
+pub use backend::RefSlice;
 
 /// Trait implemented by types that support creating `BitmapSlice` objects.
 pub trait WithBitmapSlice<'a> {

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -14,7 +14,7 @@ use std::fmt::Debug;
 use crate::{GuestMemory, GuestMemoryRegion};
 
 #[cfg(any(test, feature = "backend-bitmap"))]
-pub use backend::RefSlice;
+pub use backend::{AtomicBitmap, RefSlice};
 
 /// Trait implemented by types that support creating `BitmapSlice` objects.
 pub trait WithBitmapSlice<'a> {

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -109,3 +109,311 @@ pub type BS<'a, B> = <B as WithBitmapSlice<'a>>::S;
 /// Helper type alias for referring to the `BitmapSlice` concrete type associated with
 /// the memory regions of an object `M: GuestMemory`.
 pub type MS<'a, M> = BS<'a, <<M as GuestMemory>::R as GuestMemoryRegion>::B>;
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    use std::io::Cursor;
+    use std::marker::PhantomData;
+    use std::mem::size_of_val;
+    use std::result::Result;
+    use std::sync::atomic::Ordering;
+
+    use crate::{Bytes, VolatileMemory};
+    #[cfg(feature = "backend-mmap")]
+    use crate::{GuestAddress, MemoryRegionAddress};
+
+    // Helper method to check whether a specified range is clean.
+    pub fn range_is_clean<B: Bitmap>(b: &B, start: usize, len: usize) -> bool {
+        (start..start + len).all(|offset| !b.dirty_at(offset))
+    }
+
+    // Helper method to check whether a specified range is dirty.
+    pub fn range_is_dirty<B: Bitmap>(b: &B, start: usize, len: usize) -> bool {
+        (start..start + len).all(|offset| b.dirty_at(offset))
+    }
+
+    pub fn check_range<B: Bitmap>(b: &B, start: usize, len: usize, clean: bool) -> bool {
+        if clean {
+            range_is_clean(b, start, len)
+        } else {
+            range_is_dirty(b, start, len)
+        }
+    }
+
+    // Helper method that tests a generic `B: Bitmap` implementation. It assumes `b` covers
+    // an area of length at least 0x2000.
+    pub fn test_bitmap<B: Bitmap>(b: &B) {
+        let len = 0x2000;
+        let dirty_offset = 0x1000;
+        let dirty_len = 0x100;
+
+        // Some basic checks.
+        let s = b.slice_at(dirty_offset);
+
+        assert!(range_is_clean(b, 0, len));
+        assert!(range_is_clean(&s, 0, dirty_len));
+
+        b.mark_dirty(dirty_offset, dirty_len);
+        assert!(range_is_dirty(b, dirty_offset, dirty_len));
+        assert!(range_is_dirty(&s, 0, dirty_len));
+    }
+
+    #[derive(Debug)]
+    pub enum TestAccessError {
+        RangeCleanCheck,
+        RangeDirtyCheck,
+    }
+
+    // A helper object that implements auxiliary operations for testing `Bytes` implementations
+    // in the context of dirty bitmap tracking.
+    struct BytesHelper<F, G, M> {
+        check_range_fn: F,
+        address_fn: G,
+        phantom: PhantomData<*const M>,
+    }
+
+    // `F` represents a closure the checks whether a specified range associated with the `Bytes`
+    // object that's being tested is marked as dirty or not (depending on the value of the last
+    // parameter). It has the following parameters:
+    // - A reference to a `Bytes` implementations that's subject to testing.
+    // - The offset of the range.
+    // - The length of the range.
+    // - Whether we are checking if the range is clean (when `true`) or marked as dirty.
+    //
+    // `G` represents a closure that translates an offset into an address value that's
+    // relevant for the `Bytes` implementation being tested.
+    impl<F, G, M, A> BytesHelper<F, G, M>
+    where
+        F: Fn(&M, usize, usize, bool) -> bool,
+        G: Fn(usize) -> A,
+        M: Bytes<A>,
+    {
+        fn check_range(&self, m: &M, start: usize, len: usize, clean: bool) -> bool {
+            (self.check_range_fn)(m, start, len, clean)
+        }
+
+        fn address(&self, offset: usize) -> A {
+            (self.address_fn)(offset)
+        }
+
+        fn test_access<Op>(
+            &self,
+            bytes: &M,
+            dirty_offset: usize,
+            dirty_len: usize,
+            op: Op,
+        ) -> Result<(), TestAccessError>
+        where
+            Op: Fn(&M, A),
+        {
+            if !self.check_range(bytes, dirty_offset, dirty_len, true) {
+                return Err(TestAccessError::RangeCleanCheck);
+            }
+
+            op(bytes, self.address(dirty_offset));
+
+            if !self.check_range(bytes, dirty_offset, dirty_len, false) {
+                return Err(TestAccessError::RangeDirtyCheck);
+            }
+
+            Ok(())
+        }
+    }
+
+    // `F` and `G` stand for the same closure types as described in the `BytesHelper` comment.
+    // The `step` parameter represents the offset that's added the the current address after
+    // performing each access. It provides finer grained control when testing tracking
+    // implementations that aggregate entire ranges for accounting purposes (for example, doing
+    // tracking at the page level).
+    pub fn test_bytes<F, G, M, A>(bytes: &M, check_range_fn: F, address_fn: G, step: usize)
+    where
+        F: Fn(&M, usize, usize, bool) -> bool,
+        G: Fn(usize) -> A,
+        A: Copy,
+        M: Bytes<A>,
+        <M as Bytes<A>>::E: Debug,
+    {
+        const BUF_SIZE: usize = 1024;
+        let buf = vec![1u8; 1024];
+
+        let val = 1u64;
+
+        let h = BytesHelper {
+            check_range_fn,
+            address_fn,
+            phantom: PhantomData,
+        };
+
+        let mut dirty_offset = 0x1000;
+
+        // Test `write`.
+        h.test_access(bytes, dirty_offset, BUF_SIZE, |m, addr| {
+            assert_eq!(m.write(buf.as_slice(), addr).unwrap(), BUF_SIZE)
+        })
+        .unwrap();
+        dirty_offset += step;
+
+        // Test `write_slice`.
+        h.test_access(bytes, dirty_offset, BUF_SIZE, |m, addr| {
+            m.write_slice(buf.as_slice(), addr).unwrap()
+        })
+        .unwrap();
+        dirty_offset += step;
+
+        // Test `write_obj`.
+        h.test_access(bytes, dirty_offset, size_of_val(&val), |m, addr| {
+            m.write_obj(val, addr).unwrap()
+        })
+        .unwrap();
+        dirty_offset += step;
+
+        // Test `read_from`.
+        h.test_access(bytes, dirty_offset, BUF_SIZE, |m, addr| {
+            assert_eq!(
+                m.read_from(addr, &mut Cursor::new(&buf), BUF_SIZE).unwrap(),
+                BUF_SIZE
+            )
+        })
+        .unwrap();
+        dirty_offset += step;
+
+        // Test `read_exact_from`.
+        h.test_access(bytes, dirty_offset, BUF_SIZE, |m, addr| {
+            m.read_exact_from(addr, &mut Cursor::new(&buf), BUF_SIZE)
+                .unwrap()
+        })
+        .unwrap();
+        dirty_offset += step;
+
+        // Test `store`.
+        h.test_access(bytes, dirty_offset, size_of_val(&val), |m, addr| {
+            m.store(val, addr, Ordering::Relaxed).unwrap()
+        })
+        .unwrap();
+    }
+
+    // This function and the next are currently conditionally compiled because we only use
+    // them to test the mmap-based backend implementations for now. Going forward, the generic
+    // test functions defined here can be placed in a separate module (i.e. `test_utilities`)
+    // which is gated by a feature and can be used for testing purposes by other crates as well.
+    #[cfg(feature = "backend-mmap")]
+    fn test_guest_memory_region<R: GuestMemoryRegion>(region: &R) {
+        let dirty_addr = MemoryRegionAddress(0x0);
+        let val = 123u64;
+        let dirty_len = size_of_val(&val);
+
+        let slice = region.get_slice(dirty_addr, dirty_len).unwrap();
+
+        assert!(range_is_clean(region.bitmap(), 0, region.len() as usize));
+        assert!(range_is_clean(slice.bitmap(), 0, dirty_len));
+
+        region.write_obj(val, dirty_addr).unwrap();
+
+        assert!(range_is_dirty(
+            region.bitmap(),
+            dirty_addr.0 as usize,
+            dirty_len
+        ));
+
+        assert!(range_is_dirty(slice.bitmap(), 0, dirty_len));
+
+        // Finally, let's invoke the generic tests for `R: Bytes`. It's ok to pass the same
+        // `region` handle because `test_bytes` starts performing writes after the range that's
+        // been already dirtied in the first part of this test.
+        test_bytes(
+            region,
+            |r: &R, start: usize, len: usize, clean: bool| {
+                check_range(r.bitmap(), start, len, clean)
+            },
+            |offset| MemoryRegionAddress(offset as u64),
+            0x1000,
+        );
+    }
+
+    #[cfg(feature = "backend-mmap")]
+    // Assumptions about M generated by f ...
+    pub fn test_guest_memory_and_region<M, F>(f: F)
+    where
+        M: GuestMemory,
+        F: Fn() -> M,
+    {
+        let m = f();
+        let dirty_addr = GuestAddress(0x1000);
+        let val = 123u64;
+        let dirty_len = size_of_val(&val);
+
+        let (region, region_addr) = m.to_region_addr(dirty_addr).unwrap();
+        let slice = m.get_slice(dirty_addr, dirty_len).unwrap();
+
+        assert!(range_is_clean(region.bitmap(), 0, region.len() as usize));
+        assert!(range_is_clean(slice.bitmap(), 0, dirty_len));
+
+        m.write_obj(val, dirty_addr).unwrap();
+
+        assert!(range_is_dirty(
+            region.bitmap(),
+            region_addr.0 as usize,
+            dirty_len
+        ));
+
+        assert!(range_is_dirty(slice.bitmap(), 0, dirty_len));
+
+        // Now let's invoke the tests for the inner `GuestMemoryRegion` type.
+        test_guest_memory_region(f().find_region(GuestAddress(0)).unwrap());
+
+        // Finally, let's invoke the generic tests for `Bytes`.
+        let check_range_closure = |m: &M, start: usize, len: usize, clean: bool| -> bool {
+            let mut check_result = true;
+            m.try_access(len, GuestAddress(start as u64), |_, size, reg_addr, reg| {
+                if !check_range(reg.bitmap(), reg_addr.0 as usize, size, clean) {
+                    check_result = false;
+                }
+                Ok(size)
+            })
+            .unwrap();
+
+            check_result
+        };
+
+        test_bytes(
+            &f(),
+            check_range_closure,
+            |offset| GuestAddress(offset as u64),
+            0x1000,
+        );
+    }
+
+    pub fn test_volatile_memory<M: VolatileMemory>(m: &M) {
+        assert!(m.len() >= 0x8000);
+
+        let dirty_offset = 0x1000;
+        let val = 123u64;
+        let dirty_len = size_of_val(&val);
+
+        let get_ref_offset = 0x2000;
+        let array_ref_offset = 0x3000;
+
+        let s1 = m.as_volatile_slice();
+        let s2 = m.get_slice(dirty_offset, dirty_len).unwrap();
+
+        assert!(range_is_clean(s1.bitmap(), 0, s1.len()));
+        assert!(range_is_clean(s2.bitmap(), 0, s2.len()));
+
+        s1.write_obj(val, dirty_offset).unwrap();
+
+        assert!(range_is_dirty(s1.bitmap(), dirty_offset, dirty_len));
+        assert!(range_is_dirty(s2.bitmap(), 0, dirty_len));
+
+        let v_ref = m.get_ref::<u64>(get_ref_offset).unwrap();
+        assert!(range_is_clean(s1.bitmap(), get_ref_offset, dirty_len));
+        v_ref.store(val);
+        assert!(range_is_dirty(s1.bitmap(), get_ref_offset, dirty_len));
+
+        let arr_ref = m.get_array_ref::<u64>(array_ref_offset, 1).unwrap();
+        assert!(range_is_clean(s1.bitmap(), array_ref_offset, dirty_len));
+        arr_ref.store(0, val);
+        assert!(range_is_dirty(s1.bitmap(), array_ref_offset, dirty_len));
+    }
+}

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -1,0 +1,105 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+//! This module holds abstractions that enable tracking the areas dirtied by writes of a specified
+//! length to a given offset. In particular, this is used to track write accesses within a
+//! `GuestMemoryRegion` object, and the resulting bitmaps can then be aggregated to build the
+//! global view for an entire `GuestMemory` object.
+
+use std::fmt::Debug;
+
+use crate::{GuestMemory, GuestMemoryRegion};
+
+/// Trait implemented by types that support creating `BitmapSlice` objects.
+pub trait WithBitmapSlice<'a> {
+    /// Type of the bitmap slice.
+    type S: BitmapSlice;
+}
+
+/// Trait used to represent that a `BitmapSlice` is a `Bitmap` itself, but also satisfies the
+/// restriction that slices created from it have the same type as `Self`.
+pub trait BitmapSlice:
+    Bitmap + Clone + Copy + Debug + for<'a> WithBitmapSlice<'a, S = Self>
+{
+}
+
+/// Common bitmap operations. Using Higher-Rank Trait Bounds (HRTBs) to effectively define
+/// an associated type that has a lifetime parameter, without tagging the `Bitmap` trait with
+/// a lifetime as well.
+///
+/// Using an associated type allows implementing the `Bitmap` and `BitmapSlice` functionality
+/// as a zero-cost abstraction when providing trivial implementations such as the one
+/// defined for `()`.
+// These methods represent the core functionality that's required by `vm-memory` abstractions
+// to implement generic tracking logic, as well as tests that can be reused by different backends.
+pub trait Bitmap: for<'a> WithBitmapSlice<'a> {
+    /// Mark the memory range specified by the given `offset` and `len` as dirtied.
+    fn mark_dirty(&self, offset: usize, len: usize);
+
+    /// Check whether the specified `offset` is marked as dirty.
+    fn dirty_at(&self, offset: usize) -> bool;
+
+    /// Return a `<Self as WithBitmapSlice>::S` slice of the current bitmap, starting at
+    /// the specified `offset`.
+    fn slice_at(&self, offset: usize) -> <Self as WithBitmapSlice>::S;
+}
+
+/// A no-op `Bitmap` implementation that can be provided for backends that do not actually
+/// require the tracking functionality.
+
+impl<'a> WithBitmapSlice<'a> for () {
+    type S = Self;
+}
+
+impl BitmapSlice for () {}
+
+impl Bitmap for () {
+    fn mark_dirty(&self, _offset: usize, _len: usize) {}
+
+    fn dirty_at(&self, _offset: usize) -> bool {
+        false
+    }
+
+    fn slice_at(&self, _offset: usize) -> Self {}
+}
+
+/// A `Bitmap` and `BitmapSlice` implementation for `Option<B>`.
+
+impl<'a, B> WithBitmapSlice<'a> for Option<B>
+where
+    B: WithBitmapSlice<'a>,
+{
+    type S = Option<B::S>;
+}
+
+impl<B: BitmapSlice> BitmapSlice for Option<B> {}
+
+impl<B: Bitmap> Bitmap for Option<B> {
+    fn mark_dirty(&self, offset: usize, len: usize) {
+        if let Some(inner) = self {
+            inner.mark_dirty(offset, len)
+        }
+    }
+
+    fn dirty_at(&self, offset: usize) -> bool {
+        if let Some(inner) = self {
+            return inner.dirty_at(offset);
+        }
+        false
+    }
+
+    fn slice_at(&self, offset: usize) -> Option<<B as WithBitmapSlice>::S> {
+        if let Some(inner) = self {
+            return Some(inner.slice_at(offset));
+        }
+        None
+    }
+}
+
+/// Helper type alias for referring to the `BitmapSlice` concrete type associated with
+/// an object `B: WithBitmapSlice<'a>`.
+pub type BS<'a, B> = <B as WithBitmapSlice<'a>>::S;
+
+/// Helper type alias for referring to the `BitmapSlice` concrete type associated with
+/// the memory regions of an object `M: GuestMemory`.
+pub type MS<'a, M> = BS<'a, <<M as GuestMemory>::R as GuestMemoryRegion>::B>;

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -18,7 +18,7 @@ use std::slice::{from_raw_parts, from_raw_parts_mut};
 use std::sync::atomic::Ordering;
 
 use crate::atomic_integer::AtomicInteger;
-use crate::VolatileSlice;
+use crate::volatile_memory::VolatileSlice;
 
 /// Types for which it is safe to initialize from raw data.
 ///

--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -288,7 +288,7 @@ pub trait GuestMemoryRegion: Bytes<MemoryRegionAddress, E = Error> {
     /// # use vm_memory::{GuestAddress, MmapRegion, GuestRegionMmap, GuestMemoryRegion};
     /// # use vm_memory::volatile_memory::{VolatileMemory, VolatileSlice, VolatileRef};
     /// #
-    /// let region = MmapRegion::new(0x400).expect("Could not create mmap region");
+    /// let region = MmapRegion::<()>::new(0x400).expect("Could not create mmap region");
     /// let region =
     ///     GuestRegionMmap::new(region, GuestAddress(0x0)).expect("Could not create guest memory");
     /// let slice = region
@@ -318,7 +318,7 @@ pub trait GuestMemoryRegion: Bytes<MemoryRegionAddress, E = Error> {
     /// # {
     /// #   use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap, GuestRegionMmap};
     /// let addr = GuestAddress(0x1000);
-    /// let mem = GuestMemoryMmap::from_ranges(&[(addr, 0x1000)]).unwrap();
+    /// let mem = GuestMemoryMmap::<()>::from_ranges(&[(addr, 0x1000)]).unwrap();
     /// let r = mem.find_region(addr).unwrap();
     /// assert_eq!(r.is_hugetlbfs(), None);
     /// # }
@@ -362,27 +362,27 @@ pub trait GuestMemoryRegion: Bytes<MemoryRegionAddress, E = Error> {
 ///     }
 /// }
 ///
-/// fn get_mmap() -> GuestMemoryMmap {
+/// fn get_mmap() -> GuestMemoryMmap<()> {
 ///     let start_addr = GuestAddress(0x1000);
 ///     GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)])
 ///         .expect("Could not create guest memory")
 /// }
 ///
 /// // Using `VirtioDevice` with an immutable GuestMemoryMmap:
-/// let mut for_immutable_mmap = VirtioDevice::<&GuestMemoryMmap>::new();
+/// let mut for_immutable_mmap = VirtioDevice::<&GuestMemoryMmap<()>>::new();
 /// let mmap = get_mmap();
 /// for_immutable_mmap.activate(&mmap);
-/// let mut another = VirtioDevice::<&GuestMemoryMmap>::new();
+/// let mut another = VirtioDevice::<&GuestMemoryMmap<()>>::new();
 /// another.activate(&mmap);
 ///
 /// # #[cfg(feature = "backend-atomic")]
 /// # {
 /// # use vm_memory::GuestMemoryAtomic;
 /// // Using `VirtioDevice` with a mutable GuestMemoryMmap:
-/// let mut for_mutable_mmap = VirtioDevice::<GuestMemoryAtomic<GuestMemoryMmap>>::new();
+/// let mut for_mutable_mmap = VirtioDevice::<GuestMemoryAtomic<GuestMemoryMmap<()>>>::new();
 /// let atomic = GuestMemoryAtomic::new(get_mmap());
 /// for_mutable_mmap.activate(atomic.clone());
-/// let mut another = VirtioDevice::<GuestMemoryAtomic<GuestMemoryMmap>>::new();
+/// let mut another = VirtioDevice::<GuestMemoryAtomic<GuestMemoryMmap<()>>>::new();
 /// another.activate(atomic.clone());
 ///
 /// // atomic can be modified here...
@@ -530,7 +530,7 @@ pub trait GuestMemory {
     /// #
     /// let start_addr1 = GuestAddress(0x0);
     /// let start_addr2 = GuestAddress(0x400);
-    /// let gm = GuestMemoryMmap::from_ranges(&vec![(start_addr1, 1024), (start_addr2, 2048)])
+    /// let gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr1, 1024), (start_addr2, 2048)])
     ///     .expect("Could not create guest memory");
     ///
     /// let total_size = gm
@@ -566,7 +566,7 @@ pub trait GuestMemory {
     /// #
     /// let start_addr1 = GuestAddress(0x0);
     /// let start_addr2 = GuestAddress(0x400);
-    /// let gm = GuestMemoryMmap::from_ranges(&vec![(start_addr1, 1024), (start_addr2, 2048)])
+    /// let gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr1, 1024), (start_addr2, 2048)])
     ///     .expect("Could not create guest memory");
     ///
     /// let total_size = gm.map_and_fold(0, |(_, region)| region.len() / 1024, |acc, size| acc + size);
@@ -593,7 +593,7 @@ pub trait GuestMemory {
     /// # use vm_memory::{Address, GuestAddress, GuestMemory, GuestMemoryMmap};
     /// #
     /// let start_addr = GuestAddress(0x1000);
-    /// let mut gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)])
+    /// let mut gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr, 0x400)])
     ///     .expect("Could not create guest memory");
     ///
     /// assert_eq!(start_addr.checked_add(0x3ff), Some(gm.last_addr()));
@@ -705,7 +705,7 @@ pub trait GuestMemory {
     /// # use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap};
     /// #
     /// # let start_addr = GuestAddress(0x1000);
-    /// # let mut gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x500)])
+    /// # let mut gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr, 0x500)])
     /// #    .expect("Could not create guest memory");
     /// #
     /// let addr = gm
@@ -762,7 +762,7 @@ impl<T: GuestMemory> Bytes<GuestAddress> for T {
     /// # use vm_memory::{Bytes, GuestAddress, mmap::GuestMemoryMmap};
     /// #
     /// # let start_addr = GuestAddress(0x1000);
-    /// # let mut gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)])
+    /// # let mut gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr, 0x400)])
     /// #    .expect("Could not create guest memory");
     /// #
     /// gm.write_slice(&[1, 2, 3, 4, 5], start_addr)
@@ -790,7 +790,7 @@ impl<T: GuestMemory> Bytes<GuestAddress> for T {
     /// # use vm_memory::{Bytes, GuestAddress, mmap::GuestMemoryMmap};
     /// #
     /// let start_addr = GuestAddress(0x1000);
-    /// let mut gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)])
+    /// let mut gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr, 0x400)])
     ///     .expect("Could not create guest memory");
     /// let buf = &mut [0u8; 16];
     ///
@@ -821,7 +821,7 @@ impl<T: GuestMemory> Bytes<GuestAddress> for T {
     /// # use std::path::Path;
     /// #
     /// # let start_addr = GuestAddress(0x1000);
-    /// # let gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)])
+    /// # let gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr, 0x400)])
     /// #    .expect("Could not create guest memory");
     /// # let addr = GuestAddress(0x1010);
     /// # let mut file = if cfg!(unix) {
@@ -910,7 +910,7 @@ impl<T: GuestMemory> Bytes<GuestAddress> for T {
     /// # use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
     /// #
     /// # let start_addr = GuestAddress(0x1000);
-    /// # let gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 1024)])
+    /// # let gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr, 1024)])
     /// #    .expect("Could not create guest memory");
     /// # let mut file = if cfg!(unix) {
     /// # use std::fs::OpenOptions;
@@ -975,7 +975,7 @@ impl<T: GuestMemory> Bytes<GuestAddress> for T {
     /// # use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
     /// #
     /// # let start_addr = GuestAddress(0x1000);
-    /// # let gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 1024)])
+    /// # let gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr, 1024)])
     /// #    .expect("Could not create guest memory");
     /// # let mut file = if cfg!(unix) {
     /// # use std::fs::OpenOptions;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,8 @@ pub use atomic::{GuestMemoryAtomic, GuestMemoryLoadGuard};
 mod atomic_integer;
 pub use atomic_integer::AtomicInteger;
 
+pub mod bitmap;
+
 pub mod bytes;
 pub use bytes::{AtomicAccess, ByteValued, Bytes};
 

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -175,7 +175,7 @@ impl<B: Bitmap> Bytes<MemoryRegionAddress> for GuestRegionMmap<B> {
     /// # use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
     /// #
     /// # let start_addr = GuestAddress(0x1000);
-    /// # let mut gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)])
+    /// # let mut gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr, 0x400)])
     /// #    .expect("Could not create guest memory");
     /// #
     /// let res = gm
@@ -198,7 +198,7 @@ impl<B: Bitmap> Bytes<MemoryRegionAddress> for GuestRegionMmap<B> {
     /// # use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
     /// #
     /// # let start_addr = GuestAddress(0x1000);
-    /// # let mut gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)])
+    /// # let mut gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr, 0x400)])
     /// #    .expect("Could not create guest memory");
     /// #
     /// let buf = &mut [0u8; 16];
@@ -241,7 +241,7 @@ impl<B: Bitmap> Bytes<MemoryRegionAddress> for GuestRegionMmap<B> {
     /// # use std::path::Path;
     /// #
     /// # let start_addr = GuestAddress(0x1000);
-    /// # let gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)])
+    /// # let gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr, 0x400)])
     /// #    .expect("Could not create guest memory");
     /// # let addr = GuestAddress(0x1010);
     /// # let mut file = if cfg!(unix) {
@@ -286,7 +286,7 @@ impl<B: Bitmap> Bytes<MemoryRegionAddress> for GuestRegionMmap<B> {
     /// # use std::path::Path;
     /// #
     /// # let start_addr = GuestAddress(0x1000);
-    /// # let gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)])
+    /// # let gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr, 0x400)])
     /// #    .expect("Could not create guest memory");
     /// # let addr = GuestAddress(0x1010);
     /// # let mut file = if cfg!(unix) {
@@ -333,7 +333,7 @@ impl<B: Bitmap> Bytes<MemoryRegionAddress> for GuestRegionMmap<B> {
     /// # use vm_memory::{Address, Bytes, GuestAddress, GuestMemoryMmap};
     /// #
     /// # let start_addr = GuestAddress(0x1000);
-    /// # let gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)])
+    /// # let gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr, 0x400)])
     /// #    .expect("Could not create guest memory");
     /// # let mut file = if cfg!(unix) {
     /// # use std::fs::OpenOptions;
@@ -378,7 +378,7 @@ impl<B: Bitmap> Bytes<MemoryRegionAddress> for GuestRegionMmap<B> {
     /// # use vm_memory::{Address, Bytes, GuestAddress, GuestMemoryMmap};
     /// #
     /// # let start_addr = GuestAddress(0x1000);
-    /// # let gm = GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)])
+    /// # let gm = GuestMemoryMmap::<()>::from_ranges(&vec![(start_addr, 0x400)])
     /// #    .expect("Could not create guest memory");
     /// # let mut file = if cfg!(unix) {
     /// # use std::fs::OpenOptions;

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -669,6 +669,8 @@ mod tests {
 
     use super::*;
 
+    use crate::bitmap::tests::test_guest_memory_and_region;
+    use crate::bitmap::AtomicBitmap;
     use crate::GuestAddressSpace;
 
     use std::fs::File;
@@ -1557,5 +1559,13 @@ mod tests {
             MemoryRegionAddress(0),
             MemoryRegionAddress(0x1000),
         );
+    }
+
+    #[test]
+    fn test_dirty_tracking() {
+        test_guest_memory_and_region(|| {
+            crate::GuestMemoryMmap::<AtomicBitmap>::from_ranges(&[(GuestAddress(0), 0x1_0000)])
+                .unwrap()
+        });
     }
 }

--- a/src/mmap_unix.rs
+++ b/src/mmap_unix.rs
@@ -17,8 +17,9 @@ use std::os::unix::io::AsRawFd;
 use std::ptr::null_mut;
 use std::result;
 
+use crate::bitmap::{Bitmap, BS};
 use crate::guest_memory::FileOffset;
-use crate::mmap::{check_file_offset, AsSlice};
+use crate::mmap::{check_file_offset, AsSlice, NewBitmap};
 use crate::volatile_memory::{self, compute_offset, VolatileMemory, VolatileSlice};
 
 /// Error conditions that may arise when creating a new `MmapRegion` object.
@@ -83,9 +84,10 @@ pub type Result<T> = result::Result<T, Error>;
 /// physical memory may be mapped into the current process due to the limited virtual address
 /// space size of the process.
 #[derive(Debug)]
-pub struct MmapRegion {
+pub struct MmapRegion<B = ()> {
     addr: *mut u8,
     size: usize,
+    bitmap: B,
     file_offset: Option<FileOffset>,
     prot: i32,
     flags: i32,
@@ -97,10 +99,10 @@ pub struct MmapRegion {
 // Accessing that pointer is only done through the stateless interface which
 // allows the object to be shared by multiple threads without a decrease in
 // safety.
-unsafe impl Send for MmapRegion {}
-unsafe impl Sync for MmapRegion {}
+unsafe impl<B: Send> Send for MmapRegion<B> {}
+unsafe impl<B: Sync> Sync for MmapRegion<B> {}
 
-impl MmapRegion {
+impl<B: NewBitmap> MmapRegion<B> {
     /// Creates a shared anonymous mapping of `size` bytes.
     ///
     /// # Arguments
@@ -169,6 +171,7 @@ impl MmapRegion {
         Ok(Self {
             addr: addr as *mut u8,
             size,
+            bitmap: B::with_len(size),
             file_offset,
             prot,
             flags,
@@ -211,6 +214,7 @@ impl MmapRegion {
         Ok(Self {
             addr,
             size,
+            bitmap: B::with_len(size),
             file_offset: None,
             prot,
             flags,
@@ -218,8 +222,12 @@ impl MmapRegion {
             hugetlbfs: None,
         })
     }
+}
 
-    /// Returns a pointer to the beginning of the memory region.
+impl<B: Bitmap> MmapRegion<B> {
+    /// Returns a pointer to the beginning of the memory region. Mutable accesses performed
+    /// using the resulting pointer are not automatically accounted for by the dirty bitmap
+    /// tracking functionality.
     ///
     /// Should only be used for passing this region to ioctls for setting guest memory.
     pub fn as_ptr(&self) -> *mut u8 {
@@ -256,7 +264,7 @@ impl MmapRegion {
     ///
     /// This is mostly a sanity check available for convenience, as different file descriptors
     /// can alias the same file.
-    pub fn fds_overlap(&self, other: &MmapRegion) -> bool {
+    pub fn fds_overlap<T: Bitmap>(&self, other: &MmapRegion<T>) -> bool {
         if let Some(f_off1) = self.file_offset() {
             if let Some(f_off2) = other.file_offset() {
                 if f_off1.file().as_raw_fd() == f_off2.file().as_raw_fd() {
@@ -285,9 +293,14 @@ impl MmapRegion {
     pub fn is_hugetlbfs(&self) -> Option<bool> {
         self.hugetlbfs
     }
+
+    /// Returns a reference to the inner bitmap object.
+    pub fn bitmap(&self) -> &B {
+        &self.bitmap
+    }
 }
 
-impl AsSlice for MmapRegion {
+impl<B> AsSlice for MmapRegion<B> {
     unsafe fn as_slice(&self) -> &[u8] {
         // This is safe because we mapped the area at addr ourselves, so this slice will not
         // overflow. However, it is possible to alias.
@@ -302,12 +315,18 @@ impl AsSlice for MmapRegion {
     }
 }
 
-impl VolatileMemory for MmapRegion {
+impl<B: Bitmap> VolatileMemory for MmapRegion<B> {
+    type B = B;
+
     fn len(&self) -> usize {
         self.size
     }
 
-    fn get_slice(&self, offset: usize, count: usize) -> volatile_memory::Result<VolatileSlice> {
+    fn get_slice(
+        &self,
+        offset: usize,
+        count: usize,
+    ) -> volatile_memory::Result<VolatileSlice<BS<B>>> {
         let end = compute_offset(offset, count)?;
         if end > self.size {
             return Err(volatile_memory::Error::OutOfBounds { addr: end });
@@ -315,11 +334,17 @@ impl VolatileMemory for MmapRegion {
 
         // Safe because we checked that offset + count was within our range and we only ever hand
         // out volatile accessors.
-        Ok(unsafe { VolatileSlice::new((self.addr as usize + offset) as *mut _, count) })
+        Ok(unsafe {
+            VolatileSlice::with_bitmap(
+                (self.addr as usize + offset) as *mut _,
+                count,
+                self.bitmap.slice_at(offset),
+            )
+        })
     }
 }
 
-impl Drop for MmapRegion {
+impl<B> Drop for MmapRegion<B> {
     fn drop(&mut self) {
         // This is safe because we mmap the area at addr ourselves, and nobody
         // else is holding a reference to it.
@@ -339,6 +364,8 @@ mod tests {
     use std::slice;
     use std::sync::Arc;
     use vmm_sys_util::tempfile::TempFile;
+
+    type MmapRegion = super::MmapRegion<()>;
 
     // Adding a helper method to extract the errno within an Error::Mmap(e), or return a
     // distinctive value when the error is represented by another variant.

--- a/src/mmap_unix.rs
+++ b/src/mmap_unix.rs
@@ -365,6 +365,8 @@ mod tests {
     use std::sync::Arc;
     use vmm_sys_util::tempfile::TempFile;
 
+    use crate::bitmap::AtomicBitmap;
+
     type MmapRegion = super::MmapRegion<()>;
 
     // Adding a helper method to extract the errno within an Error::Mmap(e), or return a
@@ -559,5 +561,13 @@ mod tests {
         // R2 is not file backed, so no overlap.
         let r2 = MmapRegion::new(5000).unwrap();
         assert!(!r1.fds_overlap(&r2));
+    }
+
+    #[test]
+    fn test_dirty_tracking() {
+        // Using the `crate` prefix because we aliased `MmapRegion` to `MmapRegion<()>` for
+        // the rest of the unit tests above.
+        let m = crate::MmapRegion::<AtomicBitmap>::new(0x1_0000).unwrap();
+        crate::bitmap::tests::test_volatile_memory(&m);
     }
 }

--- a/src/volatile_memory.rs
+++ b/src/volatile_memory.rs
@@ -38,6 +38,7 @@ use std::sync::atomic::Ordering;
 use std::usize;
 
 use crate::atomic_integer::AtomicInteger;
+use crate::bitmap::{Bitmap, BitmapSlice, BS};
 use crate::{AtomicAccess, ByteValued, Bytes};
 
 use copy_slice_impl::copy_slice;
@@ -119,6 +120,9 @@ pub fn compute_offset(base: usize, offset: usize) -> Result<usize> {
 
 /// Types that support raw volatile access to their data.
 pub trait VolatileMemory {
+    /// Type used for dirty memory tracking.
+    type B: Bitmap;
+
     /// Gets the size of this slice.
     fn len(&self) -> usize;
 
@@ -129,26 +133,30 @@ pub trait VolatileMemory {
 
     /// Returns a [`VolatileSlice`](struct.VolatileSlice.html) of `count` bytes starting at
     /// `offset`.
-    fn get_slice(&self, offset: usize, count: usize) -> Result<VolatileSlice>;
+    fn get_slice(&self, offset: usize, count: usize) -> Result<VolatileSlice<BS<Self::B>>>;
 
     /// Gets a slice of memory for the entire region that supports volatile access.
-    fn as_volatile_slice(&self) -> VolatileSlice {
+    fn as_volatile_slice(&self) -> VolatileSlice<BS<Self::B>> {
         self.get_slice(0, self.len()).unwrap()
     }
 
     /// Gets a `VolatileRef` at `offset`.
-    fn get_ref<T: ByteValued>(&self, offset: usize) -> Result<VolatileRef<T>> {
+    fn get_ref<T: ByteValued>(&self, offset: usize) -> Result<VolatileRef<T, BS<Self::B>>> {
         let slice = self.get_slice(offset, size_of::<T>())?;
         unsafe {
             // This is safe because the pointer is range-checked by get_slice, and
             // the lifetime is the same as self.
-            Ok(VolatileRef::<T>::new(slice.addr))
+            Ok(VolatileRef::with_bitmap(slice.addr, slice.bitmap))
         }
     }
 
     /// Returns a [`VolatileArrayRef`](struct.VolatileArrayRef.html) of `n` elements starting at
     /// `offset`.
-    fn get_array_ref<T: ByteValued>(&self, offset: usize, n: usize) -> Result<VolatileArrayRef<T>> {
+    fn get_array_ref<T: ByteValued>(
+        &self,
+        offset: usize,
+        n: usize,
+    ) -> Result<VolatileArrayRef<T, BS<Self::B>>> {
         // Use isize to avoid problems with ptr::offset and ptr::add down the line.
         let nbytes = isize::try_from(n)
             .ok()
@@ -161,7 +169,7 @@ pub trait VolatileMemory {
         unsafe {
             // This is safe because the pointer is range-checked by get_slice, and
             // the lifetime is the same as self.
-            Ok(VolatileArrayRef::<T>::new(slice.addr, n))
+            Ok(VolatileArrayRef::with_bitmap(slice.addr, n, slice.bitmap))
         }
     }
 
@@ -181,7 +189,9 @@ pub trait VolatileMemory {
         Ok(&*(slice.addr as *const T))
     }
 
-    /// Returns a mutable reference to an instance of `T` at `offset`.
+    /// Returns a mutable reference to an instance of `T` at `offset`. Mutable accesses performed
+    /// using the resulting reference are not automatically accounted for by the dirty bitmap
+    /// tracking functionality.
     ///
     /// # Safety
     ///
@@ -195,10 +205,13 @@ pub trait VolatileMemory {
     unsafe fn aligned_as_mut<T: ByteValued>(&self, offset: usize) -> Result<&mut T> {
         let slice = self.get_slice(offset, size_of::<T>())?;
         slice.check_alignment(align_of::<T>())?;
+
         Ok(&mut *(slice.addr as *mut T))
     }
 
-    /// Returns a reference to an instance of `T` at `offset`.
+    /// Returns a reference to an instance of `T` at `offset`. Mutable accesses performed
+    /// using the resulting reference are not automatically accounted for by the dirty bitmap
+    /// tracking functionality.
     ///
     /// # Errors
     ///
@@ -226,11 +239,13 @@ pub trait VolatileMemory {
 }
 
 impl<'a> VolatileMemory for &'a mut [u8] {
+    type B = ();
+
     fn len(&self) -> usize {
         <[u8]>::len(self)
     }
 
-    fn get_slice(&self, offset: usize, count: usize) -> Result<VolatileSlice> {
+    fn get_slice(&self, offset: usize, count: usize) -> Result<VolatileSlice<()>> {
         let _ = self.compute_end_offset(offset, count)?;
         unsafe {
             // This is safe because the pointer is range-checked by compute_end_offset, and
@@ -247,14 +262,15 @@ impl<'a> VolatileMemory for &'a mut [u8] {
 struct Packed<T>(T);
 
 /// A slice of raw memory that supports volatile access.
-#[derive(Copy, Clone, Debug)]
-pub struct VolatileSlice<'a> {
+#[derive(Clone, Copy, Debug)]
+pub struct VolatileSlice<'a, B = ()> {
     addr: *mut u8,
     size: usize,
+    bitmap: B,
     phantom: PhantomData<&'a u8>,
 }
 
-impl<'a> VolatileSlice<'a> {
+impl<'a> VolatileSlice<'a, ()> {
     /// Creates a slice of raw memory that must support volatile access.
     ///
     /// # Safety
@@ -264,14 +280,32 @@ impl<'a> VolatileSlice<'a> {
     /// must also guarantee that all other users of the given chunk of memory are using volatile
     /// accesses.
     pub unsafe fn new(addr: *mut u8, size: usize) -> VolatileSlice<'a> {
+        Self::with_bitmap(addr, size, ())
+    }
+}
+
+impl<'a, B: BitmapSlice> VolatileSlice<'a, B> {
+    /// Creates a slice of raw memory that must support volatile access, and uses the provided
+    /// `bitmap` object for dirty page tracking.
+    ///
+    /// # Safety
+    ///
+    /// To use this safely, the caller must guarantee that the memory at `addr` is `size` bytes long
+    /// and is available for the duration of the lifetime of the new `VolatileSlice`. The caller
+    /// must also guarantee that all other users of the given chunk of memory are using volatile
+    /// accesses.
+    pub unsafe fn with_bitmap(addr: *mut u8, size: usize, bitmap: B) -> VolatileSlice<'a, B> {
         VolatileSlice {
             addr,
             size,
+            bitmap,
             phantom: PhantomData,
         }
     }
 
-    /// Returns a pointer to the beginning of the slice.
+    /// Returns a pointer to the beginning of the slice. Mutable accesses performed
+    /// using the resulting pointer are not automatically accounted for by the dirty bitmap
+    /// tracking functionality.
     pub fn as_ptr(&self) -> *mut u8 {
         self.addr
     }
@@ -284,6 +318,11 @@ impl<'a> VolatileSlice<'a> {
     /// Checks if the slice is empty.
     pub fn is_empty(&self) -> bool {
         self.size == 0
+    }
+
+    /// Borrows the inner `BitmapSlice`.
+    pub fn bitmap(&self) -> &B {
+        &self.bitmap
     }
 
     /// Divides one slice into two at an index.
@@ -306,12 +345,13 @@ impl<'a> VolatileSlice<'a> {
     /// assert_eq!(8, start.len());
     /// assert_eq!(24, end.len());
     /// ```
-    pub fn split_at(self, mid: usize) -> Result<(VolatileSlice<'a>, VolatileSlice<'a>)> {
+    pub fn split_at(self, mid: usize) -> Result<(Self, Self)> {
         let end = self.offset(mid)?;
         let start = unsafe {
             // safe because self.offset() already checked the bounds
-            VolatileSlice::new(self.addr, mid)
+            VolatileSlice::with_bitmap(self.addr, mid, self.bitmap)
         };
+
         Ok((start, end))
     }
 
@@ -320,7 +360,7 @@ impl<'a> VolatileSlice<'a> {
     ///
     /// The returned subslice is a copy of this slice with the address increased by `offset` bytes
     /// and the size set to `count` bytes.
-    pub fn subslice(self, offset: usize, count: usize) -> Result<VolatileSlice<'a>> {
+    pub fn subslice(self, offset: usize, count: usize) -> Result<Self> {
         let mem_end = compute_offset(offset, count)?;
         if mem_end > self.len() {
             return Err(Error::OutOfBounds { addr: mem_end });
@@ -328,9 +368,10 @@ impl<'a> VolatileSlice<'a> {
         unsafe {
             // This is safe because the pointer is range-checked by compute_end_offset, and
             // the lifetime is the same as the original slice.
-            Ok(VolatileSlice::new(
+            Ok(VolatileSlice::with_bitmap(
                 (self.as_ptr() as usize + offset) as *mut u8,
                 count,
+                self.bitmap.slice_at(offset),
             ))
         }
     }
@@ -340,7 +381,7 @@ impl<'a> VolatileSlice<'a> {
     ///
     /// The returned subslice is a copy of this slice with the address increased by `count` bytes
     /// and the size reduced by `count` bytes.
-    pub fn offset(self, count: usize) -> Result<VolatileSlice<'a>> {
+    pub fn offset(self, count: usize) -> Result<VolatileSlice<'a, B>> {
         let new_addr = (self.addr as usize)
             .checked_add(count)
             .ok_or(Error::Overflow {
@@ -354,7 +395,11 @@ impl<'a> VolatileSlice<'a> {
         unsafe {
             // Safe because the memory has the same lifetime and points to a subset of the
             // memory of the original slice.
-            Ok(VolatileSlice::new(new_addr as *mut u8, new_size))
+            Ok(VolatileSlice::with_bitmap(
+                new_addr as *mut u8,
+                new_size,
+                self.bitmap.slice_at(count),
+            ))
         }
     }
 
@@ -424,13 +469,15 @@ impl<'a> VolatileSlice<'a> {
     ///         .expect("Could not get VolatileSlice"),
     /// );
     /// ```
-    pub fn copy_to_volatile_slice(&self, slice: VolatileSlice) {
+    pub fn copy_to_volatile_slice<S: BitmapSlice>(&self, slice: VolatileSlice<S>) {
         unsafe {
             // Safe because the pointers are range-checked when the slices
             // are created, and they never escape the VolatileSlices.
             // FIXME: ... however, is it really okay to mix non-volatile
             // operations such as copy with read_volatile and write_volatile?
-            copy(self.addr, slice.addr, min(self.size, slice.size));
+            let count = min(self.size, slice.size);
+            copy(self.addr, slice.addr, count);
+            slice.bitmap.mark_dirty(0, count);
         }
     }
 
@@ -471,12 +518,18 @@ impl<'a> VolatileSlice<'a> {
             let dst = unsafe { self.as_mut_slice() };
             // Safe because `T` is a one-byte data structure.
             let src = unsafe { from_raw_parts(buf.as_ptr() as *const u8, buf.len()) };
-            copy_slice(dst, src);
+            let count = copy_slice(dst, src);
+            self.bitmap.mark_dirty(0, count * size_of::<T>());
         } else {
             let count = self.size / size_of::<T>();
+            // It's ok to use unwrap here because `count` was computed based on the current
+            // length of `self`.
             let dest = self.get_array_ref::<T>(0, count).unwrap();
-            dest.copy_from(buf)
-        }
+
+            // No need to explicitly call `mark_dirty` after this call because
+            // `VolatileArrayRef::copy_from` already takes care of that.
+            dest.copy_from(buf);
+        };
     }
 
     /// Returns a slice corresponding to the data in the underlying memory.
@@ -489,12 +542,15 @@ impl<'a> VolatileSlice<'a> {
         from_raw_parts(self.addr, self.size)
     }
 
-    /// Returns a mutable slice corresponding to the data in the underlying memory.
+    /// Returns a mutable slice corresponding to the data in the underlying memory. Writes to the
+    /// slice have to be tracked manually using the handle returned by `VolatileSlice::bitmap`.
     ///
     /// # Safety
     ///
     /// This function is private and only used for the read/write functions. It is not valid in
-    /// general to take slices of volatile memory.
+    /// general to take slices of volatile memory. Mutable accesses performed through the returned
+    /// slice are not visible to the dirty bitmap tracking functionality, and must be manually
+    /// recorded using the associated bitmap object.
     #[allow(clippy::mut_from_ref)]
     unsafe fn as_mut_slice(&self) -> &mut [u8] {
         from_raw_parts_mut(self.addr, self.size)
@@ -514,7 +570,7 @@ impl<'a> VolatileSlice<'a> {
     }
 }
 
-impl Bytes<usize> for VolatileSlice<'_> {
+impl<B: BitmapSlice> Bytes<usize> for VolatileSlice<'_, B> {
     type E = Error;
 
     /// # Examples
@@ -540,7 +596,10 @@ impl Bytes<usize> for VolatileSlice<'_> {
         // volatile.  Writing to it with what is essentially a fancy memcpy
         // won't hurt anything as long as we get the bounds checks right.
         let slice = unsafe { self.as_mut_slice() }.split_at_mut(addr).1;
-        Ok(copy_slice(slice, buf))
+
+        let count = copy_slice(slice, buf);
+        self.bitmap.mark_dirty(addr, count);
+        Ok(count)
     }
 
     /// # Examples
@@ -589,6 +648,7 @@ impl Bytes<usize> for VolatileSlice<'_> {
     /// assert_eq!(res.unwrap(), ());
     /// ```
     fn write_slice(&self, buf: &[u8], addr: usize) -> Result<()> {
+        // `mark_dirty` called within `self.write`.
         let len = self.write(buf, addr)?;
         if len != buf.len() {
             return Err(Error::PartialBuffer {
@@ -657,19 +717,22 @@ impl Bytes<usize> for VolatileSlice<'_> {
         F: Read,
     {
         let end = self.compute_end_offset(addr, count)?;
-        unsafe {
+        let bytes_read = unsafe {
             // It is safe to overwrite the volatile memory. Accessing the guest
             // memory as a mutable slice is OK because nothing assumes another
             // thread won't change what is loaded.
             let dst = &mut self.as_mut_slice()[addr..end];
             loop {
                 match src.read(dst) {
-                    Ok(n) => break Ok(n),
+                    Ok(n) => break n,
                     Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
-                    Err(e) => break Err(Error::IOError(e)),
+                    Err(e) => return Err(Error::IOError(e)),
                 }
             }
-        }
+        };
+
+        self.bitmap.mark_dirty(addr, bytes_read);
+        Ok(bytes_read)
     }
 
     /// # Examples
@@ -701,14 +764,15 @@ impl Bytes<usize> for VolatileSlice<'_> {
         F: Read,
     {
         let end = self.compute_end_offset(addr, count)?;
-        unsafe {
-            // It is safe to overwrite the volatile memory. Accessing the guest
-            // memory as a mutable slice is OK because nothing assumes another
-            // thread won't change what is loaded.
-            let dst = &mut self.as_mut_slice()[addr..end];
-            src.read_exact(dst).map_err(Error::IOError)?;
-        }
-        Ok(())
+
+        // It is safe to overwrite the volatile memory. Accessing the guest memory as a mutable
+        // slice is OK because nothing assumes another thread won't change what is loaded. We also
+        // manually update the dirty bitmap below.
+        let dst = unsafe { &mut self.as_mut_slice()[addr..end] };
+
+        let result = src.read_exact(dst).map_err(Error::IOError);
+        self.bitmap.mark_dirty(addr, count);
+        result
     }
 
     /// # Examples
@@ -743,7 +807,7 @@ impl Bytes<usize> for VolatileSlice<'_> {
             // It is safe to read from volatile memory. Accessing the guest
             // memory as a slice is OK because nothing assumes another thread
             // won't change what is loaded.
-            let src = &self.as_mut_slice()[addr..end];
+            let src = &self.as_slice()[addr..end];
             loop {
                 match dst.write(src) {
                     Ok(n) => break Ok(n),
@@ -786,15 +850,17 @@ impl Bytes<usize> for VolatileSlice<'_> {
             // It is safe to read from volatile memory. Accessing the guest
             // memory as a slice is OK because nothing assumes another thread
             // won't change what is loaded.
-            let src = &self.as_mut_slice()[addr..end];
+            let src = &self.as_slice()[addr..end];
             dst.write_all(src).map_err(Error::IOError)?;
         }
         Ok(())
     }
 
     fn store<T: AtomicAccess>(&self, val: T, addr: usize, order: Ordering) -> Result<()> {
-        self.get_atomic_ref::<T::A>(addr)
-            .map(|r| r.store(val.into(), order))
+        self.get_atomic_ref::<T::A>(addr).map(|r| {
+            r.store(val.into(), order);
+            self.bitmap.mark_dirty(addr, size_of::<T>())
+        })
     }
 
     fn load<T: AtomicAccess>(&self, addr: usize, order: Ordering) -> Result<T> {
@@ -803,17 +869,23 @@ impl Bytes<usize> for VolatileSlice<'_> {
     }
 }
 
-impl VolatileMemory for VolatileSlice<'_> {
+impl<B: BitmapSlice> VolatileMemory for VolatileSlice<'_, B> {
+    type B = B;
+
     fn len(&self) -> usize {
         self.size
     }
 
-    fn get_slice(&self, offset: usize, count: usize) -> Result<VolatileSlice> {
+    fn get_slice(&self, offset: usize, count: usize) -> Result<VolatileSlice<B>> {
         let _ = self.compute_end_offset(offset, count)?;
         Ok(unsafe {
             // This is safe because the pointer is range-checked by compute_end_offset, and
             // the lifetime is the same as self.
-            VolatileSlice::new((self.addr as usize + offset) as *mut u8, count)
+            VolatileSlice::with_bitmap(
+                (self.addr as usize + offset) as *mut u8,
+                count,
+                self.bitmap.slice_at(offset),
+            )
         })
     }
 }
@@ -826,7 +898,7 @@ impl VolatileMemory for VolatileSlice<'_> {
 /// # use vm_memory::VolatileRef;
 /// #
 /// let mut v = 5u32;
-/// let v_ref = unsafe { VolatileRef::<u32>::new(&mut v as *mut u32 as *mut u8) };
+/// let v_ref = unsafe { VolatileRef::new(&mut v as *mut u32 as *mut u8) };
 ///
 /// assert_eq!(v, 5);
 /// assert_eq!(v_ref.load(), 5);
@@ -834,16 +906,16 @@ impl VolatileMemory for VolatileSlice<'_> {
 /// assert_eq!(v, 500);
 /// ```
 #[derive(Clone, Copy, Debug)]
-pub struct VolatileRef<'a, T: ByteValued>
-where
-    T: 'a,
-{
+pub struct VolatileRef<'a, T, B = ()> {
     addr: *mut Packed<T>,
+    bitmap: B,
     phantom: PhantomData<&'a T>,
 }
 
-#[allow(clippy::len_without_is_empty)]
-impl<'a, T: ByteValued> VolatileRef<'a, T> {
+impl<'a, T> VolatileRef<'a, T, ()>
+where
+    T: ByteValued,
+{
     /// Creates a [`VolatileRef`](struct.VolatileRef.html) to an instance of `T`.
     ///
     /// # Safety
@@ -852,9 +924,30 @@ impl<'a, T: ByteValued> VolatileRef<'a, T> {
     /// `T` and is available for the duration of the lifetime of the new `VolatileRef`. The caller
     /// must also guarantee that all other users of the given chunk of memory are using volatile
     /// accesses.
-    pub unsafe fn new(addr: *mut u8) -> VolatileRef<'a, T> {
+    pub unsafe fn new(addr: *mut u8) -> Self {
+        Self::with_bitmap(addr, ())
+    }
+}
+
+#[allow(clippy::len_without_is_empty)]
+impl<'a, T, B> VolatileRef<'a, T, B>
+where
+    T: ByteValued,
+    B: BitmapSlice,
+{
+    /// Creates a [`VolatileRef`](struct.VolatileRef.html) to an instance of `T`, using the
+    /// provided `bitmap` object for dirty page tracking.
+    ///
+    /// # Safety
+    ///
+    /// To use this safely, the caller must guarantee that the memory at `addr` is big enough for a
+    /// `T` and is available for the duration of the lifetime of the new `VolatileRef`. The caller
+    /// must also guarantee that all other users of the given chunk of memory are using volatile
+    /// accesses.
+    pub unsafe fn with_bitmap(addr: *mut u8, bitmap: B) -> Self {
         VolatileRef {
             addr: addr as *mut Packed<T>,
+            bitmap,
             phantom: PhantomData,
         }
     }
@@ -879,10 +972,16 @@ impl<'a, T: ByteValued> VolatileRef<'a, T> {
         size_of::<T>()
     }
 
+    /// Borrows the inner `BitmapSlice`.
+    pub fn bitmap(&self) -> &B {
+        &self.bitmap
+    }
+
     /// Does a volatile write of the value `v` to the address of this ref.
     #[inline(always)]
     pub fn store(self, v: T) {
         unsafe { write_volatile(self.addr, Packed::<T>(v)) };
+        self.bitmap.mark_dirty(0, size_of::<T>())
     }
 
     /// Does a volatile read of the value at the address of this ref.
@@ -896,8 +995,8 @@ impl<'a, T: ByteValued> VolatileRef<'a, T> {
 
     /// Converts this to a [`VolatileSlice`](struct.VolatileSlice.html) with the same size and
     /// address.
-    pub fn to_slice(self) -> VolatileSlice<'a> {
-        unsafe { VolatileSlice::new(self.addr as *mut u8, size_of::<T>()) }
+    pub fn to_slice(self) -> VolatileSlice<'a, B> {
+        unsafe { VolatileSlice::with_bitmap(self.addr as *mut u8, size_of::<T>(), self.bitmap) }
     }
 }
 
@@ -909,7 +1008,7 @@ impl<'a, T: ByteValued> VolatileRef<'a, T> {
 /// # use vm_memory::VolatileArrayRef;
 /// #
 /// let mut v = [5u32; 1];
-/// let v_ref = unsafe { VolatileArrayRef::<u32>::new(&mut v[0] as *mut u32 as *mut u8, v.len()) };
+/// let v_ref = unsafe { VolatileArrayRef::new(&mut v[0] as *mut u32 as *mut u8, v.len()) };
 ///
 /// assert_eq!(v[0], 5);
 /// assert_eq!(v_ref.load(0), 5);
@@ -917,16 +1016,17 @@ impl<'a, T: ByteValued> VolatileRef<'a, T> {
 /// assert_eq!(v[0], 500);
 /// ```
 #[derive(Clone, Copy, Debug)]
-pub struct VolatileArrayRef<'a, T: ByteValued>
-where
-    T: 'a,
-{
+pub struct VolatileArrayRef<'a, T, B = ()> {
     addr: *mut u8,
     nelem: usize,
+    bitmap: B,
     phantom: PhantomData<&'a T>,
 }
 
-impl<'a, T: ByteValued> VolatileArrayRef<'a, T> {
+impl<'a, T> VolatileArrayRef<'a, T>
+where
+    T: ByteValued,
+{
     /// Creates a [`VolatileArrayRef`](struct.VolatileArrayRef.html) to an array of elements of
     /// type `T`.
     ///
@@ -936,10 +1036,30 @@ impl<'a, T: ByteValued> VolatileArrayRef<'a, T> {
     /// `nelem` values of type `T` and is available for the duration of the lifetime of the new
     /// `VolatileRef`. The caller must also guarantee that all other users of the given chunk of
     /// memory are using volatile accesses.
-    pub unsafe fn new(addr: *mut u8, nelem: usize) -> VolatileArrayRef<'a, T> {
+    pub unsafe fn new(addr: *mut u8, nelem: usize) -> Self {
+        Self::with_bitmap(addr, nelem, ())
+    }
+}
+
+impl<'a, T, B> VolatileArrayRef<'a, T, B>
+where
+    T: ByteValued,
+    B: BitmapSlice,
+{
+    /// Creates a [`VolatileArrayRef`](struct.VolatileArrayRef.html) to an array of elements of
+    /// type `T`, using the provided `bitmap` object for dirty page tracking.
+    ///
+    /// # Safety
+    ///
+    /// To use this safely, the caller must guarantee that the memory at `addr` is big enough for
+    /// `nelem` values of type `T` and is available for the duration of the lifetime of the new
+    /// `VolatileRef`. The caller must also guarantee that all other users of the given chunk of
+    /// memory are using volatile accesses.
+    pub unsafe fn with_bitmap(addr: *mut u8, nelem: usize, bitmap: B) -> Self {
         VolatileArrayRef {
             addr,
             nelem,
+            bitmap,
             phantom: PhantomData,
         }
     }
@@ -987,18 +1107,27 @@ impl<'a, T: ByteValued> VolatileArrayRef<'a, T> {
         size_of::<T>()
     }
 
-    /// Returns a pointer to the underlying memory.
+    /// Returns a pointer to the underlying memory. Mutable accesses performed
+    /// using the resulting pointer are not automatically accounted for by the dirty bitmap
+    /// tracking functionality.
     pub fn as_ptr(&self) -> *mut u8 {
         self.addr
     }
 
+    /// Borrows the inner `BitmapSlice`.
+    pub fn bitmap(&self) -> &B {
+        &self.bitmap
+    }
+
     /// Converts this to a `VolatileSlice` with the same size and address.
-    pub fn to_slice(&self) -> VolatileSlice<'a> {
-        unsafe { VolatileSlice::new(self.addr, self.nelem * self.element_size()) }
+    pub fn to_slice(&self) -> VolatileSlice<'a, B> {
+        unsafe {
+            VolatileSlice::with_bitmap(self.addr, self.nelem * self.element_size(), self.bitmap)
+        }
     }
 
     /// Does a volatile read of the element at `index`.
-    pub fn ref_at(&self, index: usize) -> VolatileRef<'a, T> {
+    pub fn ref_at(&self, index: usize) -> VolatileRef<'a, T, B> {
         assert!(index < self.nelem);
         // Safe because the memory has the same lifetime and points to a subset of the
         // memory of the VolatileArrayRef.
@@ -1006,7 +1135,7 @@ impl<'a, T: ByteValued> VolatileArrayRef<'a, T> {
             // byteofs must fit in an isize as it was checked in get_array_ref.
             let byteofs = (self.element_size() * index) as isize;
             let ptr = self.as_ptr().offset(byteofs);
-            VolatileRef::new(ptr)
+            VolatileRef::with_bitmap(ptr, self.bitmap.slice_at(byteofs as usize))
         }
     }
 
@@ -1017,6 +1146,8 @@ impl<'a, T: ByteValued> VolatileArrayRef<'a, T> {
 
     /// Does a volatile write of the element at `index`.
     pub fn store(&self, index: usize, value: T) {
+        // The `VolatileRef::store` call below implements the required dirty bitmap tracking logic,
+        // so no need to do that in this method as well.
         self.ref_at(index).store(value)
     }
 
@@ -1032,7 +1163,7 @@ impl<'a, T: ByteValued> VolatileArrayRef<'a, T> {
     /// # use vm_memory::VolatileArrayRef;
     /// #
     /// let mut v = [0u8; 32];
-    /// let v_ref = unsafe { VolatileArrayRef::<u8>::new(&mut v[0] as *mut u8, v.len()) };
+    /// let v_ref = unsafe { VolatileArrayRef::new(&mut v[0] as *mut u8, v.len()) };
     ///
     /// let mut buf = [5u8; 16];
     /// v_ref.copy_to(&mut buf[..]);
@@ -1087,17 +1218,15 @@ impl<'a, T: ByteValued> VolatileArrayRef<'a, T> {
     ///     assert_eq!(v, 0);
     /// }
     /// ```
-    pub fn copy_to_volatile_slice(&self, slice: VolatileSlice) {
+    pub fn copy_to_volatile_slice<S: BitmapSlice>(&self, slice: VolatileSlice<S>) {
         unsafe {
             // Safe because the pointers are range-checked when the slices
             // are created, and they never escape the VolatileSlices.
             // FIXME: ... however, is it really okay to mix non-volatile
             // operations such as copy with read_volatile and write_volatile?
-            copy(
-                self.addr,
-                slice.addr,
-                min(self.len() * self.element_size(), slice.size),
-            );
+            let count = min(self.len() * self.element_size(), slice.size);
+            copy(self.addr, slice.addr, count);
+            slice.bitmap.mark_dirty(0, count);
         }
     }
 
@@ -1130,7 +1259,8 @@ impl<'a, T: ByteValued> VolatileArrayRef<'a, T> {
             let dst = unsafe { destination.as_mut_slice() };
             // Safe because `T` is a one-byte data structure.
             let src = unsafe { from_raw_parts(buf.as_ptr() as *const u8, buf.len()) };
-            copy_slice(dst, src);
+            let count = copy_slice(dst, src);
+            self.bitmap.mark_dirty(0, count);
         } else {
             let mut addr = self.addr;
             for &v in buf.iter().take(self.len()) {
@@ -1143,15 +1273,18 @@ impl<'a, T: ByteValued> VolatileArrayRef<'a, T> {
                     addr = addr.add(self.element_size());
                 }
             }
+
+            self.bitmap
+                .mark_dirty(0, addr as usize - self.addr as usize)
         }
     }
 }
 
-impl<'a> From<VolatileSlice<'a>> for VolatileArrayRef<'a, u8> {
-    fn from(slice: VolatileSlice<'a>) -> Self {
+impl<'a, B: BitmapSlice> From<VolatileSlice<'a, B>> for VolatileArrayRef<'a, u8, B> {
+    fn from(slice: VolatileSlice<'a, B>) -> Self {
         // Safe because the result has the same lifetime and points to the same
         // memory as the incoming VolatileSlice.
-        unsafe { VolatileArrayRef::new(slice.as_ptr(), slice.len()) }
+        unsafe { VolatileArrayRef::with_bitmap(slice.as_ptr(), slice.len(), slice.bitmap) }
     }
 }
 
@@ -1249,11 +1382,13 @@ mod tests {
     }
 
     impl VolatileMemory for VecMem {
+        type B = ();
+
         fn len(&self) -> usize {
             self.mem.len()
         }
 
-        fn get_slice(&self, offset: usize, count: usize) -> Result<VolatileSlice> {
+        fn get_slice(&self, offset: usize, count: usize) -> Result<VolatileSlice<()>> {
             let _ = self.compute_end_offset(offset, count)?;
             Ok(unsafe {
                 VolatileSlice::new((self.mem.as_ptr() as usize + offset) as *mut _, count)
@@ -1760,7 +1895,7 @@ mod tests {
         let a_vec = a.to_vec();
         let a_ref = &mut a[..];
         let a_slice = a_ref.get_slice(0, a_ref.len()).unwrap();
-        let a_array_ref: VolatileArrayRef<u8> = a_slice.into();
+        let a_array_ref: VolatileArrayRef<u8, ()> = a_slice.into();
         for (i, entry) in a_vec.iter().enumerate() {
             assert_eq!(&a_array_ref.load(i), entry);
         }


### PR DESCRIPTION
This PR contains an initial proposal to tackle the problem of dirty page/region tracking within a `GuestMemory` object, which happens at the level of each individual region here. We add the `Bitmap` interface, the `BitmapSlice` abstraction (which is passed to objects such as `VolatileSlice`s to enable tracking local accesses in the context of the outer `GuestMemoryRegion`), and begin to add the necessary invocations of tracking functionality  around write accesses. Here are some details and open questions:

- The PR also removes several things (for example, the `VolatileMemory` impls for `MmapRegion` and `&mut [u8]`). I did a quick investigation and it looked like these implementations where not specifically used outside the crate, and I think this also simplifies things a bit. They can be added back and made compatible with the current changes if necessary.

- An open question is what to do (w.r.t. tracking) with methods that return mutable slices or references (the bigger question is whether we should actually have them at all, but that's outside of the current scope :D). My preference is to add the lack of tracking to the safety contract of methods like `as_mut_slice` (i.e. the caller must manually mark the areas that get written to), and to remove (either completely or just from the public interface) methods such as `get_atomic_ref` and `aligned_as_mut` from `VolatileMemory`. One alternative is to treat them like `as_mut_slice`, but this kinda means we're increasing the number of moving parts that have to be taken into account, and most of their use cases are already covered by the `Bytes` interface (there's just `load` and `store` for atomic ops right now, but we can add the rest as well if required). WDYT?

- A potentially significant (and breaking) change is the additional generic type parameter for `Volatile{Slice,Ref,ArrayRef}`. Its purpose is turning this into a zero-cost abstraction (as far as accesses are concerned), and to allow different tracking implementations to be used. The change can become unwieldy if there are a lot of fields/variable definitions that explicitly mention the type, and one way around this is to create a type alias instead of replacing everything. `GuestMemoryMmap` and `GuestRegionMmap` also get an additional type parameter which represents the bitmap implementation in use.

Looking forward to any comments!  If this makes sense, I'll start adding the scaffolding required to test things for generic`Bytes` implementations as well as specific mutable accesses that are enabled by the various `vm-memory` primitives.