### PR TITLE
Add Configurable Page Size Policy to MmapRegion

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -122,6 +122,22 @@ let buf = &mut [0u8; 5];
 let result = guest_memory_mmap.write(buf, addr);
 ```
 
+#### Page Size Policy
+
+For regions backed by a call to `mmap`, the user may specify the desired page size
+and behavior expected by the operating system. The current options include:
+
+- `BasePages`: The standard page size provided by the operating system.
+- `TransparentHugepages`: (Implemented only for Unix-like systems) Hints to the operating
+  system that base pages can be combined transparently into larger page sizes. Concretely,
+  mappings with this policy will invoke `madvise` with the `MADV_HUGEPAGE` flag.
+- `ExplicitHugepages`: Requests that the entire mapping be explicitly mapped to a pre-reserved
+  pool of hugepages. Concretely, mappings with this policy will include the `MAP_HUGETLB` flag
+  in the call to `mmap`. **NOTE:** If the operating system has no available hugepages (e.g. on Linux,
+  if `cat /proc/sys/vm/nr_hugepages` reads 0), then the mapping, or attempts to dereference addresses
+  within the region, may fail. It is the responsibility of the VMM to ensure that hugepages are
+  available for use before constructing a mapping with this policy.
+
 ### Utilities and Helpers
 
 The following utilities and helper traits/macros are imported from the

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -70,6 +70,17 @@ pub enum Error {
     UnsortedMemoryRegions,
 }
 
+/// Page configuration types for controlling allocation size and behavior
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum PageSizePolicy {
+    /// Base pages are the smallest page-size unit available on the system.
+    BasePages,
+    /// Transparent hugepages, if available, are managed by the host operating system.
+    TransparentHugepages,
+    /// Explicit hugepages swear a lot. Especially if the addresses aren't aligned.
+    ExplicitHugepages,
+}
+
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -426,16 +437,44 @@ impl GuestMemoryMmap {
     ///
     /// Valid memory regions are specified as a slice of (Address, Size) tuples sorted by Address.
     pub fn from_ranges(ranges: &[(GuestAddress, usize)]) -> result::Result<Self, Error> {
-        Self::from_ranges_with_files(ranges.iter().map(|r| (r.0, r.1, None)))
+        Self::from_ranges_with_options(
+            ranges
+                .iter()
+                .map(|r| (r.0, r.1, PageSizePolicy::BasePages, None)),
+        )
+    }
+
+    /// Creates a container and allocates anonymous memory for guest memory regions.
+    ///
+    /// Valid memory regions are specified as asequence of (Address, Size, PageSizePolicy)
+    /// tuples sorted by Address.
+    pub fn from_ranges_with_policy(
+        ranges: &[(GuestAddress, usize, PageSizePolicy)],
+    ) -> result::Result<Self, Error> {
+        Self::from_ranges_with_options(ranges.iter().map(|r| (r.0, r.1, r.2, None)))
     }
 
     /// Creates a container and allocates anonymous memory for guest memory regions.
     ///
     /// Valid memory regions are specified as a sequence of (Address, Size, Option<FileOffset>)
     /// tuples sorted by Address.
-    pub fn from_ranges_with_files<A, T>(ranges: T) -> result::Result<Self, Error>
+    pub fn from_ranges_with_files<A, T>(
+        ranges: &[(GuestAddress, usize, Option<FileOffset>)],
+    ) -> result::Result<Self, Error> {
+        Self::from_ranges_with_options(
+            ranges
+                .iter()
+                .map(|r| (r.0, r.1, PageSizePolicy::BasePages, r.2.clone())),
+        )
+    }
+
+    /// Creates a container and allocates anonymous memory for guest memory regions.
+    ///
+    /// Valid memory regions are specified as a sequence of (Address, Size, Option<FileOffset>)
+    /// tuples sorted by Address.
+    pub fn from_ranges_with_options<A, T>(ranges: T) -> result::Result<Self, Error>
     where
-        A: Borrow<(GuestAddress, usize, Option<FileOffset>)>,
+        A: Borrow<(GuestAddress, usize, PageSizePolicy, Option<FileOffset>)>,
         T: IntoIterator<Item = A>,
     {
         Self::from_regions(
@@ -444,11 +483,12 @@ impl GuestMemoryMmap {
                 .map(|x| {
                     let guest_base = x.borrow().0;
                     let size = x.borrow().1;
+                    let policy = x.borrow().2;
 
-                    if let Some(ref f_off) = x.borrow().2 {
-                        MmapRegion::from_file(f_off.clone(), size)
+                    if let Some(ref f_off) = x.borrow().3 {
+                        MmapRegion::from_file(f_off.clone(), size, policy)
                     } else {
-                        MmapRegion::new(size)
+                        MmapRegion::new(size, policy)
                     }
                     .map_err(Error::MmapRegion)
                     .and_then(|r| GuestRegionMmap::new(r, guest_base))

--- a/src/mmap_unix.rs
+++ b/src/mmap_unix.rs
@@ -18,7 +18,7 @@ use std::ptr::null_mut;
 use std::result;
 
 use crate::guest_memory::FileOffset;
-use crate::mmap::{check_file_offset, AsSlice};
+use crate::mmap::{check_file_offset, AsSlice, PageSizePolicy};
 use crate::volatile_memory::{self, compute_offset, VolatileMemory, VolatileSlice};
 
 /// Error conditions that may arise when creating a new `MmapRegion` object.
@@ -90,6 +90,7 @@ pub struct MmapRegion {
     prot: i32,
     flags: i32,
     owned: bool,
+    policy: PageSizePolicy,
 }
 
 // Send and Sync aren't automatically inherited for the raw address pointer.
@@ -104,12 +105,13 @@ impl MmapRegion {
     ///
     /// # Arguments
     /// * `size` - The size of the memory region in bytes.
-    pub fn new(size: usize) -> Result<Self> {
+    pub fn new(size: usize, policy: PageSizePolicy) -> Result<Self> {
         Self::build(
             None,
             size,
             libc::PROT_READ | libc::PROT_WRITE,
             libc::MAP_ANONYMOUS | libc::MAP_NORESERVE | libc::MAP_PRIVATE,
+            policy,
         )
     }
 
@@ -119,12 +121,13 @@ impl MmapRegion {
     /// * `file_offset` - The mapping will be created at offset `file_offset.start` in the file
     ///                   referred to by `file_offset.file`.
     /// * `size` - The size of the memory region in bytes.
-    pub fn from_file(file_offset: FileOffset, size: usize) -> Result<Self> {
+    pub fn from_file(file_offset: FileOffset, size: usize, policy: PageSizePolicy) -> Result<Self> {
         Self::build(
             Some(file_offset),
             size,
             libc::PROT_READ | libc::PROT_WRITE,
             libc::MAP_NORESERVE | libc::MAP_SHARED,
+            policy,
         )
     }
 
@@ -143,6 +146,7 @@ impl MmapRegion {
         size: usize,
         prot: i32,
         flags: i32,
+        policy: PageSizePolicy,
     ) -> Result<Self> {
         // Forbid MAP_FIXED, as it doesn't make sense in this context, and is pretty dangerous
         // in general.
@@ -157,12 +161,26 @@ impl MmapRegion {
             (-1, 0)
         };
 
+        // Support explicit (pre-reserved) hugepages if requested
+        let flags = if policy == PageSizePolicy::ExplicitHugepages {
+            flags | libc::MAP_HUGETLB
+        } else {
+            flags
+        };
+
         // This is safe because we're not allowing MAP_FIXED, and invalid parameters cannot break
         // Rust safety guarantees (things may change if we're mapping /dev/mem or some wacky file).
         let addr = unsafe { libc::mmap(null_mut(), size, prot, flags, fd, offset as libc::off_t) };
 
         if addr == libc::MAP_FAILED {
             return Err(Error::Mmap(io::Error::last_os_error()));
+        }
+
+        // Support transparent hugepages if requested
+        if policy == PageSizePolicy::TransparentHugepages {
+            unsafe {
+                libc::madvise(addr, size, libc::MADV_HUGEPAGE);
+            };
         }
 
         Ok(Self {
@@ -172,6 +190,7 @@ impl MmapRegion {
             prot,
             flags,
             owned: true,
+            policy,
         })
     }
 
@@ -213,6 +232,7 @@ impl MmapRegion {
             prot,
             flags,
             owned: false,
+            policy: PageSizePolicy::BasePages,
         })
     }
 
@@ -246,6 +266,11 @@ impl MmapRegion {
     /// Returns `true` if the mapping is owned by this `MmapRegion` instance.
     pub fn owned(&self) -> bool {
         self.owned
+    }
+
+    /// Returns information regarding the page size policy backing this region.
+    pub fn policy(&self) -> PageSizePolicy {
+        self.policy
     }
 
     /// Checks whether this region and `other` are backed by overlapping

--- a/src/mmap_unix.rs
+++ b/src/mmap_unix.rs
@@ -105,7 +105,16 @@ impl MmapRegion {
     ///
     /// # Arguments
     /// * `size` - The size of the memory region in bytes.
-    pub fn new(size: usize, policy: PageSizePolicy) -> Result<Self> {
+    pub fn new(size: usize) -> Result<Self> {
+        Self::with_policy(size, PageSizePolicy::BasePages)
+    }
+
+    /// Creates a shared anonymous mapping of `size` bytes.
+    ///
+    /// # Arguments
+    /// * `size` - The size of the memory region in bytes.
+    /// * `policy` - The page size policy of the memory region.
+    pub fn with_policy(size: usize, policy: PageSizePolicy) -> Result<Self> {
         Self::build(
             None,
             size,
@@ -121,7 +130,22 @@ impl MmapRegion {
     /// * `file_offset` - The mapping will be created at offset `file_offset.start` in the file
     ///                   referred to by `file_offset.file`.
     /// * `size` - The size of the memory region in bytes.
-    pub fn from_file(file_offset: FileOffset, size: usize, policy: PageSizePolicy) -> Result<Self> {
+    pub fn from_file(file_offset: FileOffset, size: usize) -> Result<Self> {
+        Self::from_file_with_policy(file_offset, size, PageSizePolicy::BasePages)
+    }
+
+    /// Creates a shared file mapping of `size` bytes.
+    ///
+    /// # Arguments
+    /// * `file_offset` - The mapping will be created at offset `file_offset.start` in the file
+    ///                   referred to by `file_offset.file`.
+    /// * `size` - The size of the memory region in bytes.
+    /// * `policy` - The page size policy of the memory region.
+    pub fn from_file_with_policy(
+        file_offset: FileOffset,
+        size: usize,
+        policy: PageSizePolicy,
+    ) -> Result<Self> {
         Self::build(
             Some(file_offset),
             size,
@@ -412,6 +436,7 @@ mod tests {
             size,
             prot,
             flags,
+            PageSizePolicy::BasePages,
         );
         assert_eq!(format!("{:?}", r.unwrap_err()), "InvalidOffsetLength");
 
@@ -421,6 +446,7 @@ mod tests {
             size,
             prot,
             flags,
+            PageSizePolicy::BasePages,
         );
         assert_eq!(format!("{:?}", r.unwrap_err()), "MappingPastEof");
 
@@ -430,6 +456,7 @@ mod tests {
             size,
             prot,
             flags | libc::MAP_FIXED,
+            PageSizePolicy::BasePages,
         );
         assert_eq!(format!("{:?}", r.unwrap_err()), "MapFixed");
 
@@ -442,6 +469,7 @@ mod tests {
             size,
             prot,
             flags,
+            PageSizePolicy::BasePages,
         );
         assert_eq!(r.unwrap_err().raw_os_error(), libc::EINVAL);
 
@@ -451,6 +479,7 @@ mod tests {
             size,
             prot,
             flags,
+            PageSizePolicy::BasePages,
         )
         .unwrap();
 

--- a/src/mmap_windows.rs
+++ b/src/mmap_windows.rs
@@ -13,7 +13,7 @@ use libc::{c_void, size_t};
 use winapi::um::errhandlingapi::GetLastError;
 
 use crate::guest_memory::FileOffset;
-use crate::mmap::AsSlice;
+use crate::mmap::{AsSlice, PageSizePolicy};
 use crate::volatile_memory::{self, compute_offset, VolatileMemory, VolatileSlice};
 
 #[allow(non_snake_case)]
@@ -88,7 +88,8 @@ impl MmapRegion {
     ///
     /// # Arguments
     /// * `size` - The size of the memory region in bytes.
-    pub fn new(size: usize) -> io::Result<Self> {
+    /// * `policy` - Unimplemented on Windows platforms.
+    pub fn new(size: usize, _policy: PageSizePolicy) -> io::Result<Self> {
         if (size == 0) || (size > MM_HIGHEST_VAD_ADDRESS as usize) {
             return Err(io::Error::from_raw_os_error(libc::EINVAL));
         }
@@ -111,7 +112,12 @@ impl MmapRegion {
     /// * `file_offset` - The mapping will be created at offset `file_offset.start` in the file
     ///                   referred to by `file_offset.file`.
     /// * `size` - The size of the memory region in bytes.
-    pub fn from_file(file_offset: FileOffset, size: usize) -> io::Result<Self> {
+    /// * `policy` - Unimplemented on Windows platforms.
+    pub fn from_file(
+        file_offset: FileOffset,
+        size: usize,
+        _policy: PageSizePolicy,
+    ) -> io::Result<Self> {
         let handle = file_offset.file().as_raw_handle();
         if handle == INVALID_HANDLE_VALUE {
             return Err(io::Error::from_raw_os_error(libc::EBADF));

--- a/src/mmap_windows.rs
+++ b/src/mmap_windows.rs
@@ -88,8 +88,16 @@ impl MmapRegion {
     ///
     /// # Arguments
     /// * `size` - The size of the memory region in bytes.
+    pub fn new(size: usize) -> io::Result<Self> {
+        Self::with_policy(size, PageSizePolicy::BasePages)
+    }
+
+    /// Creates a shared anonymous mapping of `size` bytes.
+    ///
+    /// # Arguments
+    /// * `size` - The size of the memory region in bytes.
     /// * `policy` - Unimplemented on Windows platforms.
-    pub fn new(size: usize, _policy: PageSizePolicy) -> io::Result<Self> {
+    pub fn with_policy(size: usize, _policy: PageSizePolicy) -> io::Result<Self> {
         if (size == 0) || (size > MM_HIGHEST_VAD_ADDRESS as usize) {
             return Err(io::Error::from_raw_os_error(libc::EINVAL));
         }
@@ -112,8 +120,18 @@ impl MmapRegion {
     /// * `file_offset` - The mapping will be created at offset `file_offset.start` in the file
     ///                   referred to by `file_offset.file`.
     /// * `size` - The size of the memory region in bytes.
+    pub fn from_file(file_offset: FileOffset, size: usize) -> io::Result<Self> {
+        Self::from_file_with_policy(file_offset, size, PageSizePolicy::BasePages)
+    }
+
+    /// Creates a shared file mapping of `size` bytes.
+    ///
+    /// # Arguments
+    /// * `file_offset` - The mapping will be created at offset `file_offset.start` in the file
+    ///                   referred to by `file_offset.file`.
+    /// * `size` - The size of the memory region in bytes.
     /// * `policy` - Unimplemented on Windows platforms.
-    pub fn from_file(
+    pub fn from_file_with_policy(
         file_offset: FileOffset,
         size: usize,
         _policy: PageSizePolicy,


### PR DESCRIPTION
This PR adds a `PageSizePolicy` enum which can be used to configure the behavior of `MmapRegion` instances upon creation. The current options are:
- `BasePages`, which uses the default `mmap` behavior
- `TransparentHugepages`, which uses THP via `madvise`
- `ExplicitHugepages`, which passes `MAP_HUGETLB` to `mmap`

The page size policy is at a per-mapping granularity, so a given VM can have different policies for different mappings, if desired. A helper function, `from_ranges_with_policy`, allows the VMM to configure mapping policies when constructing mappings from address ranges.

The behavior is stubbed out on the `mmap_windows.rs` implementation, but the arguments are received there to allow the file to compile.

The intention of this PR is to implement the functionality required for hugepage support in vm-memory (for rust-vmm/rust-vmm#46), but without invasively modifying the external API, pending further discussion. This is mostly accomplished by adding extra constructors/functions which take a PageSizePolicy as an argument, but leaving existing functions alone.

These changes were experimentally tested for Firecracker by modifying Firecracker's local fork of vm-memory to include similar changes. Empirically, we were able to boot an Alpine microvm up to ~37% faster, and an Ubuntu microvm up to ~30% faster, reduce on-boot page faults by ~70×, all with negligible extra memory overhead. We would like to implement these changes here, so that other VMMs derived from vm-memory can hopefully reap the same benefit.

A few design questions we're not too sure about:
1. What is the _correct_ way to expose this configuration to VMMs? The way we've chosen is to add a special `from_ranges` function in `mmap.rs` that accepts a policy per tuple. However, as of recently, Firecracker is using a slightly modified local fork of vm-memory to implement dirty bit tracking, in addition to this repo. The local fork complicates how (and where) classes are used/defined (for example, it overrides `mmap.rs`), making it difficult to utilize these changes downstream. We're not sure how other downstreams of this repo use the APIs, either. Advice to improve the API is much appreciated.

2. At which level of abstraction should this policy belong? We decided to place the enum in `mmap.rs` since paging policy is closely related to mmapped regions, and not so closely related to GuestMemory in general. However, by attaching a policy to all MmapRegions, we're requiring a Windows implementation (which, for now, is just a no-op). Would it make sense to implement an `ExplicitHugepages` policy for Windows, if the OS provides that kind of control?