### PR TITLE
volatile_memory: add subslice() method to VolatileSlice

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 85.5,
+  "coverage_score": 85.6,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap,backend-atomic"
 }


### PR DESCRIPTION
VolatileSlice::subslice() returns a subslice starting from the given
`offset` with the given `size`.

Signed-off-by: Eryu Guan <eguan@linux.alibaba.com>