### PR TITLE
Add GuestMemory method to return an Iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- [[#8]](https://github.com/rust-vmm/vm-memory/issues/8): Add GuestMemory method to return an Iterator
+
 ## [v0.4.0]
 
 ### Fixed

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 85.5,
+  "coverage_score": 85.6,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap,backend-atomic"
 }


### PR DESCRIPTION
Fixes #8.

This changes is similar to #9, which was rejected as it introduced a lifetime parameter to the trait, in favor of waiting for GAT/GAL. Since GAT/GAL still looks a ways off, this change does the same thing but using [HRTBs](https://lukaskalbertodt.github.io/2018/08/03/solving-the-generalized-streaming-iterator-problem-without-gats.html#workaround-b-hrtbs--the-family-trait-pattern).