### PR TITLE
benches: fix safe conversion

### DIFF
--- a/benches/guest_memory.rs
+++ b/benches/guest_memory.rs
@@ -6,7 +6,7 @@
 pub use criterion::{black_box, Criterion};
 use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap};
 
-const REGION_SIZE: u64 = 0x10_0000;
+const REGION_SIZE: usize = 0x10_0000;
 const REGIONS_COUNT: u64 = 256;
 
 pub fn benchmark_for_guest_memory(c: &mut Criterion) {
@@ -16,7 +16,7 @@ pub fn benchmark_for_guest_memory(c: &mut Criterion) {
 fn find_region(mem: &GuestMemoryMmap) {
     for i in 0..REGIONS_COUNT {
         let _ = mem
-            .find_region(black_box(GuestAddress(i * REGION_SIZE)))
+            .find_region(black_box(GuestAddress(i * REGION_SIZE as u64)))
             .unwrap();
     }
 }

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -15,10 +15,12 @@ mod volatile;
 use volatile::benchmark_for_volatile;
 
 #[cfg(feature = "backend-mmap")]
-pub fn create_guest_memory_mmap(size: u64, count: u64) -> GuestMemoryMmap {
+// Use this function with caution. It does not check against overflows
+// and `GuestMemoryMmap::from_ranges` errors.
+fn create_guest_memory_mmap(size: usize, count: u64) -> GuestMemoryMmap {
     let mut regions: Vec<(GuestAddress, usize)> = Vec::new();
     for i in 0..count {
-        regions.push((GuestAddress(i * size), size as usize));
+        regions.push((GuestAddress(i * size as u64), size));
     }
 
     GuestMemoryMmap::from_ranges(regions.as_slice()).unwrap()

--- a/benches/mmap/mod.rs
+++ b/benches/mmap/mod.rs
@@ -15,7 +15,7 @@ use criterion::{black_box, Criterion};
 
 use vm_memory::{ByteValued, Bytes, GuestAddress, GuestMemory};
 
-const REGION_SIZE: u64 = 0x8000_0000;
+const REGION_SIZE: usize = 0x8000_0000;
 const REGIONS_COUNT: u64 = 8;
 const ACCESS_SIZE: usize = 0x200;
 
@@ -55,8 +55,10 @@ enum AccessKind {
 impl AccessKind {
     fn make_offset(&self, access_size: usize) -> u64 {
         match *self {
-            AccessKind::InRegion(idx) => REGION_SIZE * idx,
-            AccessKind::CrossRegion(idx) => REGION_SIZE * (idx + 1) - (access_size / 2) as u64,
+            AccessKind::InRegion(idx) => REGION_SIZE as u64 * idx,
+            AccessKind::CrossRegion(idx) => {
+                REGION_SIZE as u64 * (idx + 1) - (access_size as u64 / 2)
+            }
         }
     }
 }
@@ -67,7 +69,7 @@ pub fn benchmark_for_mmap(c: &mut Criterion) {
     // Just a sanity check.
     assert_eq!(
         memory.last_addr(),
-        GuestAddress(REGION_SIZE * REGIONS_COUNT - 0x01)
+        GuestAddress(REGION_SIZE as u64 * REGIONS_COUNT - 0x01)
     );
 
     let some_small_dummy = SmallDummy {


### PR DESCRIPTION
# Reason for this PR

`usize` is architecture dependent and can represent 4/8 bytes, while `u64` is an 8 byte data type. The function `create_guest_memory_mmap` implies a hidden conversion from `u64` to `usize`, which might imply data loss.

# Description of this PR

Implied conversions that can not lose data for the above case.