### PR TITLE
Implemnt builder for MmapRegion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Added
 
+  - [[#149]](https://github.com/rust-vmm/vm-memory/issues/149): Implement builder for MmapRegion
   - [[#140]](https://github.com/rust-vmm/vm-memory/issues/140): Add dirty bitmap tracking abstractions. 
 
 ### Deprecated 

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 87.6,
+  "coverage_score": 88.0,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap,backend-atomic,backend-bitmap"
 }

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -31,7 +31,7 @@ use crate::volatile_memory::{VolatileMemory, VolatileSlice};
 use crate::{AtomicAccess, Bytes};
 
 #[cfg(unix)]
-pub use crate::mmap_unix::{Error as MmapRegionError, MmapRegion};
+pub use crate::mmap_unix::{Error as MmapRegionError, MmapRegion, MmapRegionBuilder};
 
 #[cfg(windows)]
 pub use crate::mmap_windows::MmapRegion;


### PR DESCRIPTION
Currently the MmapRegion provides several methods to create MmapRegion
objects, but we often need to change the existing methods to support
new functionalities. So it would be better to adopt Builder pattern
and implement MmapRegionBuilder, so we could add new functionality
without affecting existing users.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>