### PR TITLE
bitmap: add Default bound to trait BitmapSlice

### DIFF
--- a/src/bitmap/backend/ref_slice.rs
+++ b/src/bitmap/backend/ref_slice.rs
@@ -29,6 +29,12 @@ impl<'a, B: Bitmap> WithBitmapSlice<'a> for RefSlice<'_, B> {
 
 impl<B: Bitmap> BitmapSlice for RefSlice<'_, B> {}
 
+impl<B: Bitmap> Default for RefSlice<'_, B> {
+    fn default() -> Self {
+        panic!("default() method is not supported for RefSlice");
+    }
+}
+
 impl<'a, B: Bitmap> Bitmap for RefSlice<'a, B> {
     /// Mark the memory range specified by the given `offset` (relative to the base offset of
     /// the slice) and `len` as dirtied.

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -25,7 +25,7 @@ pub trait WithBitmapSlice<'a> {
 /// Trait used to represent that a `BitmapSlice` is a `Bitmap` itself, but also satisfies the
 /// restriction that slices created from it have the same type as `Self`.
 pub trait BitmapSlice:
-    Bitmap + Clone + Copy + Debug + for<'a> WithBitmapSlice<'a, S = Self>
+    Bitmap + Clone + Copy + Debug + Default + for<'a> WithBitmapSlice<'a, S = Self>
 {
 }
 


### PR DESCRIPTION
When migrating vm-memory consumers to the new vm-memory interfaces, they
have dependence on "()::default". So add a "BitmapSlice: Default" to
ease the migration.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>