### PR TITLE
Add `ArcRef` and `AtomicBitmapArc` bitmap backend implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ### Added
 
+  - [[#160]](https://github.com/rust-vmm/vm-memory/pull/160): Add `ArcRef` and `AtomicBitmapArc` bitmap
+    backend implementations.
   - [[#149]](https://github.com/rust-vmm/vm-memory/issues/149): Implement builder for MmapRegion.
   - [[#140]](https://github.com/rust-vmm/vm-memory/issues/140): Add dirty bitmap tracking abstractions. 
 

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 88.5,
+  "coverage_score": 87.6,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap,backend-atomic,backend-bitmap"
 }

--- a/src/bitmap/backend/atomic_bitmap_arc.rs
+++ b/src/bitmap/backend/atomic_bitmap_arc.rs
@@ -1,0 +1,86 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+use std::ops::Deref;
+use std::sync::Arc;
+
+use crate::bitmap::{ArcSlice, AtomicBitmap, Bitmap, WithBitmapSlice};
+
+#[cfg(feature = "backend-mmap")]
+use crate::mmap::NewBitmap;
+
+/// A `Bitmap` implementation that's based on an atomically reference counted handle to an
+/// `AtomicBitmap` object.
+pub struct AtomicBitmapArc {
+    inner: Arc<AtomicBitmap>,
+}
+
+impl AtomicBitmapArc {
+    pub fn new(inner: AtomicBitmap) -> Self {
+        AtomicBitmapArc {
+            inner: Arc::new(inner),
+        }
+    }
+}
+
+// The current clone implementation creates a deep clone of the inner bitmap, as opposed to
+// simply cloning the `Arc`.
+impl Clone for AtomicBitmapArc {
+    fn clone(&self) -> Self {
+        Self::new(self.inner.deref().clone())
+    }
+}
+
+// Providing a `Deref` to `AtomicBitmap` implementation, so the methods of the inner object
+// can be called in a transparent manner.
+impl Deref for AtomicBitmapArc {
+    type Target = AtomicBitmap;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner.deref()
+    }
+}
+
+impl WithBitmapSlice<'_> for AtomicBitmapArc {
+    type S = ArcSlice<AtomicBitmap>;
+}
+
+impl Bitmap for AtomicBitmapArc {
+    fn mark_dirty(&self, offset: usize, len: usize) {
+        self.inner.set_addr_range(offset, len)
+    }
+
+    fn dirty_at(&self, offset: usize) -> bool {
+        self.inner.is_addr_set(offset)
+    }
+
+    fn slice_at(&self, offset: usize) -> <Self as WithBitmapSlice>::S {
+        ArcSlice::new(self.inner.clone(), offset)
+    }
+}
+
+impl Default for AtomicBitmapArc {
+    fn default() -> Self {
+        Self::new(AtomicBitmap::default())
+    }
+}
+
+#[cfg(feature = "backend-mmap")]
+impl NewBitmap for AtomicBitmapArc {
+    fn with_len(len: usize) -> Self {
+        Self::new(AtomicBitmap::with_len(len))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::bitmap::tests::test_bitmap;
+
+    #[test]
+    fn test_bitmap_impl() {
+        let b = AtomicBitmapArc::new(AtomicBitmap::new(0x2000, 128));
+        test_bitmap(&b);
+    }
+}

--- a/src/bitmap/backend/mod.rs
+++ b/src/bitmap/backend/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 mod atomic_bitmap;
-mod ref_slice;
+mod slice;
 
 pub use atomic_bitmap::AtomicBitmap;
-pub use ref_slice::RefSlice;
+pub use slice::RefSlice;

--- a/src/bitmap/backend/mod.rs
+++ b/src/bitmap/backend/mod.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 mod atomic_bitmap;
+mod atomic_bitmap_arc;
 mod slice;
 
 pub use atomic_bitmap::AtomicBitmap;
-pub use slice::RefSlice;
+pub use atomic_bitmap_arc::AtomicBitmapArc;
+pub use slice::{ArcSlice, RefSlice};

--- a/src/bitmap/backend/slice.rs
+++ b/src/bitmap/backend/slice.rs
@@ -27,7 +27,7 @@ impl<B> BaseSlice<B> {
 
 impl<'a, B> WithBitmapSlice<'a> for BaseSlice<B>
 where
-    B: Copy + Deref,
+    B: Clone + Deref,
     B::Target: Bitmap,
 {
     type S = Self;
@@ -35,14 +35,14 @@ where
 
 impl<B> BitmapSlice for BaseSlice<B>
 where
-    B: Copy + Deref,
+    B: Clone + Deref,
     B::Target: Bitmap,
 {
 }
 
 impl<B> Bitmap for BaseSlice<B>
 where
-    B: Copy + Deref,
+    B: Clone + Deref,
     B::Target: Bitmap,
 {
     /// Mark the memory range specified by the given `offset` (relative to the base offset of

--- a/src/bitmap/backend/slice.rs
+++ b/src/bitmap/backend/slice.rs
@@ -5,6 +5,7 @@
 
 use std::fmt::{self, Debug};
 use std::ops::Deref;
+use std::sync::Arc;
 
 use crate::bitmap::{Bitmap, BitmapSlice, WithBitmapSlice};
 
@@ -89,6 +90,9 @@ impl<B: Default> Default for BaseSlice<B> {
 /// A `BitmapSlice` implementation that wraps a reference to a `Bitmap` object.
 pub type RefSlice<'a, B> = BaseSlice<&'a B>;
 
+/// A `BitmapSlice` implementation that uses an `Arc` handle to a `Bitmap` object.
+pub type ArcSlice<B> = BaseSlice<Arc<B>>;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -97,7 +101,7 @@ mod tests {
     use crate::bitmap::AtomicBitmap;
 
     #[test]
-    fn test_ref_slice() {
+    fn test_slice() {
         let bitmap_size = 0x1_0000;
         let dirty_offset = 0x1000;
         let dirty_len = 0x100;

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -24,10 +24,7 @@ pub trait WithBitmapSlice<'a> {
 
 /// Trait used to represent that a `BitmapSlice` is a `Bitmap` itself, but also satisfies the
 /// restriction that slices created from it have the same type as `Self`.
-pub trait BitmapSlice:
-    Bitmap + Clone + Copy + Debug + for<'a> WithBitmapSlice<'a, S = Self>
-{
-}
+pub trait BitmapSlice: Bitmap + Clone + Debug + for<'a> WithBitmapSlice<'a, S = Self> {}
 
 /// Common bitmap operations. Using Higher-Rank Trait Bounds (HRTBs) to effectively define
 /// an associated type that has a lifetime parameter, without tagging the `Bitmap` trait with

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -14,7 +14,7 @@ use std::fmt::Debug;
 use crate::{GuestMemory, GuestMemoryRegion};
 
 #[cfg(any(test, feature = "backend-bitmap"))]
-pub use backend::{AtomicBitmap, RefSlice};
+pub use backend::{ArcSlice, AtomicBitmap, RefSlice};
 
 /// Trait implemented by types that support creating `BitmapSlice` objects.
 pub trait WithBitmapSlice<'a> {


### PR DESCRIPTION
This PR adds support for using reference counted tracking abstractions with the `bitmap` backend. `ArcSlice` stands for a bitmap into a slice that's based on `Arc` objects instead of references, and thus does not require lifetimes. `AtomicBitmapArc` is a small wrapper over `Arc<AtomicBitmap>` that makes use of `ArcSlice`s. This simplifies situations where it was difficult to handle the additional lifetimes.