### PR TITLE
Relax the trait bounds of `Bytes` auto impl for `T: GuestMemory` 

### DIFF
--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -729,7 +729,7 @@ pub trait GuestMemory {
     }
 }
 
-impl<T: GuestMemory> Bytes<GuestAddress> for T {
+impl<T: GuestMemory + ?Sized> Bytes<GuestAddress> for T {
     type E = Error;
 
     fn write(&self, buf: &[u8], addr: GuestAddress) -> Result<usize> {


### PR DESCRIPTION
Added `+ ?Sized` to the requirements of the `Bytes ` auto implementation for `T: GuestMemory`, as otherwise an unnecessary `Sized` bound was inferred.