### PR TITLE
ignore vulnerability for serde_cbor

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,6 @@
+[advisories]
+# serde_cbor is an unmaintained dependency introduced by criterion.
+# We are using criterion only for benchmarks, so we can ignore
+# this vulnerability until criterion is fixing this.
+# See https://github.com/bheisler/criterion.rs/issues/534.
+ignore = [ "RUSTSEC-2021-0127" ]


### PR DESCRIPTION
cargo audit was raising a warning for the serde_cbor dependency (which is used by criterion, so only in benchmarks) in this PR https://github.com/rust-vmm/vm-memory/pull/181. The CI didn't fail because we don't run `cargo audit` with the `--deny warnings` flag enabled. This has to be fixed in rust-vmm-ci. In vm-memory we are ignoring this vulnerability until criterion fixes the issue: https://github.com/bheisler/criterion.rs/issues/534.