### PR TITLE
Avoid needless borrow warning

### DIFF
--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -157,7 +157,7 @@ impl FileOffset {
 
     /// Returns a reference to the inner `File` object.
     pub fn file(&self) -> &File {
-        &self.file.as_ref()
+        self.file.as_ref()
     }
 
     /// Return a reference to the inner `Arc<File>` object.


### PR DESCRIPTION
The guest memory code triggers a needless borrow warning. I thought this tiny fix could be a good first contribution. :)