### PR TITLE
Manually update rust-vmm-ci

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 87.6,
+  "coverage_score": 87.8,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap,backend-atomic,backend-bitmap"
 }

--- a/src/atomic_integer.rs
+++ b/src/atomic_integer.rs
@@ -3,6 +3,8 @@
 
 use std::sync::atomic::Ordering;
 
+/// # Safety
+///
 /// Objects that implement this trait must consist exclusively of atomic types
 /// from [`std::sync::atomic`](https://doc.rust-lang.org/std/sync/atomic/), except for
 /// [`AtomicPtr<T>`](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicPtr.html) and

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -22,6 +22,8 @@ use crate::volatile_memory::VolatileSlice;
 
 /// Types for which it is safe to initialize from raw data.
 ///
+/// # Safety
+///
 /// A type `T` is `ByteValued` if and only if it can be initialized by reading its contents from a
 /// byte array.  This is generally true for all plain-old-data structs.  It is notably not true for
 /// any type that includes a reference.
@@ -55,7 +57,7 @@ pub unsafe trait ByteValued: Copy + Default + Send + Sync {
 
     /// Converts a mutable slice of raw data into a mutable reference of `Self`.
     ///
-    /// Because `Self` is made from a reference to the mutable slice`, mutations to the returned
+    /// Because `Self` is made from a reference to the mutable slice, mutations to the returned
     /// reference are immediately reflected in `data`. The value of the returned `Self` will depend
     /// on the representation of the type in memory, and may change in an unstable fashion.
     ///

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -1529,15 +1529,15 @@ mod tests {
         ])
         .unwrap();
 
-        assert_eq!(guest_mem.check_range(start_addr1, 0x0), true);
-        assert_eq!(guest_mem.check_range(start_addr1, 0x200), true);
-        assert_eq!(guest_mem.check_range(start_addr1, 0x400), true);
-        assert_eq!(guest_mem.check_range(start_addr1, 0xa00), false);
-        assert_eq!(guest_mem.check_range(start_addr2, 0x7ff), true);
-        assert_eq!(guest_mem.check_range(start_addr2, 0x800), true);
-        assert_eq!(guest_mem.check_range(start_addr2, 0x801), false);
-        assert_eq!(guest_mem.check_range(start_addr2, 0xc00), false);
-        assert_eq!(guest_mem.check_range(start_addr1, std::usize::MAX), false);
+        assert!(guest_mem.check_range(start_addr1, 0x0));
+        assert!(guest_mem.check_range(start_addr1, 0x200));
+        assert!(guest_mem.check_range(start_addr1, 0x400));
+        assert!(!guest_mem.check_range(start_addr1, 0xa00));
+        assert!(guest_mem.check_range(start_addr2, 0x7ff));
+        assert!(guest_mem.check_range(start_addr2, 0x800));
+        assert!(!guest_mem.check_range(start_addr2, 0x801));
+        assert!(!guest_mem.check_range(start_addr2, 0xc00));
+        assert!(!guest_mem.check_range(start_addr1, std::usize::MAX));
     }
 
     #[test]

--- a/src/mmap_unix.rs
+++ b/src/mmap_unix.rs
@@ -191,7 +191,7 @@ impl<B: Bitmap> MmapRegionBuilder<B> {
     fn build_raw(self) -> Result<MmapRegion<B>> {
         // Safe because this call just returns the page size and doesn't have any side effects.
         let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as usize;
-        let addr = self.raw_ptr.clone().unwrap();
+        let addr = self.raw_ptr.unwrap();
 
         // Check that the pointer to the mapping is page-aligned.
         if (addr as usize) & (page_size - 1) != 0 {


### PR DESCRIPTION
- Update the CI image to v15 with Rust 1.58.1
- Fix clippy warnings