### PR TITLE
mmap: add support for devdax and block devices

### DIFF
--- a/src/mmap_unix.rs
+++ b/src/mmap_unix.rs
@@ -29,6 +29,8 @@ pub enum Error {
     InvalidOffsetLength,
     /// The specified pointer to the mapping is not page-aligned.
     InvalidPointer,
+    /// The specified file type is invalid.
+    InvalidFileType,
     /// The forbidden `MAP_FIXED` flag was specified.
     MapFixed,
     /// Mappings using the same fd overlap in terms of file offset and length.
@@ -50,6 +52,7 @@ impl fmt::Display for Error {
                 f,
                 "The specified pointer to the mapping is not page-aligned",
             ),
+            Error::InvalidFileType => write!(f, "The specified file type is invalid"),
             Error::MapFixed => write!(f, "The forbidden `MAP_FIXED` flag was specified"),
             Error::MappingOverlap => write!(
                 f,


### PR DESCRIPTION
metadata.len() returns 0 when trying to mmap files such as block devices
and devdax (character devices) that are not regular files, hence returning
MappingPastEof even if the mapping would fit at the provided file_offset.

This patch adds support for checking the size of devdax and block devices,
and returns a new error, InvalidFileType, if the mmap being created is not
for a regular file, block or devdax device, or if the size the devices
couldn't be found in sysfs.

Usecase:
Devdax and block devices can be used in cloud-hypervisor as memory-zone.
MmapRegion::build from vm-memory is called while creating a GuestRegionMmap
for the VM memory-zone.

Reviewed-by: Fam Zheng <fam.zheng@bytedance.com>
Signed-off-by: Usama Arif <usama.arif@bytedance.com>