### PR TITLE
Add new method as_any() to GuestAddressSpace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 ## [Unreleased]
 
+### Added
+
+- [[192]](https://github.com/rust-vmm/vm-memory/pull/192): Add new method
+  as_any() to GuestAddressSpace
+
 ## [v0.8.0]
 
 ### Fixed


### PR DESCRIPTION
Add new method as_any() to GuestAddressSpace, which returns reference
to a std::any::Any trait object. Then downcast_ref() could be used to
get the concrete type of GuestAddressSpace trait object.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
