### PR TITLE
mmap: get file size with seek instead of metadata

### DIFF
--- a/src/mmap_unix.rs
+++ b/src/mmap_unix.rs
@@ -37,6 +37,10 @@ pub enum Error {
     MappingPastEof,
     /// The `mmap` call returned an error.
     Mmap(io::Error),
+    /// Seeking the end of the file returned an error.
+    SeekEnd(io::Error),
+    /// Seeking the start of the file returned an error.
+    SeekStart(io::Error),
 }
 
 impl fmt::Display for Error {
@@ -60,6 +64,8 @@ impl fmt::Display for Error {
                 "The specified file offset and length is greater then file length"
             ),
             Error::Mmap(error) => write!(f, "{}", error),
+            Error::SeekEnd(error) => write!(f, "Error seeking the end of the file: {}", error),
+            Error::SeekStart(error) => write!(f, "Error seeking the start of the file: {}", error),
         }
     }
 }


### PR DESCRIPTION
Currently mmap::check_file_offset attempts to validate the backing
object by checking, among other things, its size to confirm the
mapping will fit on it. This check is implemented by using
std::fs::metadata to obtain the file size, but this approach doesn't
work when the backing object is a block or char device, as the
returned value is always zero.

In this commit, we replace the use of std::fs:metadata with
std::io::Seek::seek(SeekEnd(0)), which works fine even with special
files such as block and char devices. As a reference, this is the
method that QEMU uses for the same goal.

Fixes: #195
Signed-off-by: Sergio Lopez <slp@redhat.com>
