### PR TITLE
atomic: enable 64 bit atomics on ppc64le and s390x

### DIFF
--- a/src/atomic_integer.rs
+++ b/src/atomic_integer.rs
@@ -53,13 +53,23 @@ macro_rules! impl_atomic_integer_ops {
 impl_atomic_integer_ops!(std::sync::atomic::AtomicI8, i8);
 impl_atomic_integer_ops!(std::sync::atomic::AtomicI16, i16);
 impl_atomic_integer_ops!(std::sync::atomic::AtomicI32, i32);
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "powerpc64",
+    target_arch = "s390x"
+))]
 impl_atomic_integer_ops!(std::sync::atomic::AtomicI64, i64);
 
 impl_atomic_integer_ops!(std::sync::atomic::AtomicU8, u8);
 impl_atomic_integer_ops!(std::sync::atomic::AtomicU16, u16);
 impl_atomic_integer_ops!(std::sync::atomic::AtomicU32, u32);
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "powerpc64",
+    target_arch = "s390x"
+))]
 impl_atomic_integer_ops!(std::sync::atomic::AtomicU64, u64);
 
 impl_atomic_integer_ops!(std::sync::atomic::AtomicIsize, isize);

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -181,13 +181,23 @@ macro_rules! impl_atomic_access {
 impl_atomic_access!(i8, std::sync::atomic::AtomicI8);
 impl_atomic_access!(i16, std::sync::atomic::AtomicI16);
 impl_atomic_access!(i32, std::sync::atomic::AtomicI32);
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "powerpc64",
+    target_arch = "s390x"
+))]
 impl_atomic_access!(i64, std::sync::atomic::AtomicI64);
 
 impl_atomic_access!(u8, std::sync::atomic::AtomicU8);
 impl_atomic_access!(u16, std::sync::atomic::AtomicU16);
 impl_atomic_access!(u32, std::sync::atomic::AtomicU32);
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "powerpc64",
+    target_arch = "s390x"
+))]
 impl_atomic_access!(u64, std::sync::atomic::AtomicU64);
 
 impl_atomic_access!(isize, std::sync::atomic::AtomicIsize);


### PR DESCRIPTION
Add ppc64le (powerpc64) and s390x to the list of arches that support
AtomicI64 and AtomicU64.

Signed-off-by: Sergio Lopez <slp@redhat.com>