### PR TITLE
mmap: Add GuestRegionMmap::from_region()

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 87.8,
+  "coverage_score": 87.1,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap,backend-atomic,backend-bitmap"
 }


### PR DESCRIPTION
All call sites are doing similar work currently, i.e. creating a MmapRegion and then passing it to GuestRegionMmap::new().

Add another variant to GuestRegionMmap, to create the structure from raw data.