### PR TITLE
Use pointers instead of slices when operating on guest memory

### DIFF
--- a/benches/volatile.rs
+++ b/benches/volatile.rs
@@ -4,19 +4,22 @@
 
 pub use criterion::{black_box, Criterion};
 use vm_memory::volatile_memory::VolatileMemory;
+use vm_memory::VolatileSlice;
 
 pub fn benchmark_for_volatile(c: &mut Criterion) {
     let mut a = [0xa5u8; 1024];
-    let a_ref = &mut a[..];
-    let v_ref8 = a_ref.get_slice(0, a_ref.len()).unwrap();
-    let v_ref16 = a_ref.get_slice(0, a_ref.len() / 2).unwrap();
+    let vslice = VolatileSlice::from(&mut a[..]);
+    let v_ref8 = vslice.get_slice(0, vslice.len()).unwrap();
     let mut d8 = [0u8; 1024];
-    let mut d16 = [0u16; 512];
 
     // Check performance for read operations.
     c.bench_function("VolatileSlice::copy_to_u8", |b| {
         b.iter(|| v_ref8.copy_to(black_box(&mut d8[..])))
     });
+
+    let v_ref16 = vslice.get_slice(0, vslice.len() / 2).unwrap();
+    let mut d16 = [0u16; 512];
+
     c.bench_function("VolatileSlice::copy_to_u16", |b| {
         b.iter(|| v_ref16.copy_to(black_box(&mut d16[..])))
     });
@@ -33,11 +36,11 @@ pub fn benchmark_for_volatile(c: &mut Criterion) {
 
 fn benchmark_volatile_copy_to_volatile_slice(c: &mut Criterion) {
     let mut a = [0xa5u8; 10240];
-    let a_ref = &mut a[..];
-    let a_slice = a_ref.get_slice(0, a_ref.len()).unwrap();
+    let vslice = VolatileSlice::from(&mut a[..]);
+    let a_slice = vslice.get_slice(0, vslice.len()).unwrap();
     let mut d = [0u8; 10240];
-    let d_ref = &mut d[..];
-    let d_slice = d_ref.get_slice(0, d_ref.len()).unwrap();
+    let vslice2 = VolatileSlice::from(&mut d[..]);
+    let d_slice = vslice2.get_slice(0, vslice2.len()).unwrap();
 
     c.bench_function("VolatileSlice::copy_to_volatile_slice", |b| {
         b.iter(|| black_box(a_slice).copy_to_volatile_slice(d_slice))

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 87.1,
+  "coverage_score": 88.9,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap,backend-atomic,backend-bitmap"
 }

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -120,7 +120,7 @@ pub unsafe trait ByteValued: Copy + Default + Send + Sync {
     /// be no other accesses).
     fn as_bytes(&mut self) -> VolatileSlice {
         // SAFETY: This is safe because the lifetime is the same as self
-        unsafe { VolatileSlice::new(self as *mut Self as usize as *mut _, size_of::<Self>()) }
+        unsafe { VolatileSlice::new(self as *mut Self as *mut _, size_of::<Self>()) }
     }
 }
 

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -50,26 +50,6 @@ impl NewBitmap for () {
     fn with_len(_len: usize) -> Self {}
 }
 
-/// Trait implemented by the underlying `MmapRegion`.
-pub(crate) trait AsSlice {
-    /// Returns a slice corresponding to the data in the underlying `MmapRegion`.
-    ///
-    /// # Safety
-    ///
-    /// This is unsafe because of possible aliasing.
-    unsafe fn as_slice(&self) -> &[u8];
-
-    /// Returns a mutable slice corresponding to the data in the underlying `MmapRegion`.
-    ///
-    /// # Safety
-    ///
-    /// This is unsafe because of possible aliasing. Accesses done through the resulting slice
-    /// are not visible to dirty bitmap tracking functionality (when present), and have to be
-    /// explicitly accounted for.
-    #[allow(clippy::mut_from_ref)]
-    unsafe fn as_mut_slice(&self) -> &mut [u8];
-}
-
 /// Errors that can occur when creating a memory map.
 #[derive(Debug)]
 pub enum Error {
@@ -484,14 +464,6 @@ impl<B: Bitmap> GuestMemoryRegion for GuestRegionMmap<B> {
 
     fn file_offset(&self) -> Option<&FileOffset> {
         self.mapping.file_offset()
-    }
-
-    unsafe fn as_slice(&self) -> Option<&[u8]> {
-        Some(self.mapping.as_slice())
-    }
-
-    unsafe fn as_mut_slice(&self) -> Option<&mut [u8]> {
-        Some(self.mapping.as_mut_slice())
     }
 
     fn get_slice(

--- a/src/mmap_unix.rs
+++ b/src/mmap_unix.rs
@@ -19,7 +19,7 @@ use std::result;
 
 use crate::bitmap::{Bitmap, BS};
 use crate::guest_memory::FileOffset;
-use crate::mmap::{check_file_offset, AsSlice, NewBitmap};
+use crate::mmap::{check_file_offset, NewBitmap};
 use crate::volatile_memory::{self, compute_offset, VolatileMemory, VolatileSlice};
 
 /// Error conditions that may arise when creating a new `MmapRegion` object.
@@ -398,21 +398,6 @@ impl<B: Bitmap> MmapRegion<B> {
     /// Returns a reference to the inner bitmap object.
     pub fn bitmap(&self) -> &B {
         &self.bitmap
-    }
-}
-
-impl<B> AsSlice for MmapRegion<B> {
-    // SAFETY: This is safe because we mapped the area at addr ourselves, so this slice will not
-    // overflow. However, it is possible to alias.
-    unsafe fn as_slice(&self) -> &[u8] {
-        std::slice::from_raw_parts(self.addr, self.size)
-    }
-
-    // SAFETY: This is safe because we mapped the area at addr ourselves, so this slice will not
-    // overflow. However, it is possible to alias.
-    #[allow(clippy::mut_from_ref)]
-    unsafe fn as_mut_slice(&self) -> &mut [u8] {
-        std::slice::from_raw_parts_mut(self.addr, self.size)
     }
 }
 

--- a/src/mmap_unix.rs
+++ b/src/mmap_unix.rs
@@ -20,7 +20,7 @@ use std::result;
 use crate::bitmap::{Bitmap, BS};
 use crate::guest_memory::FileOffset;
 use crate::mmap::{check_file_offset, NewBitmap};
-use crate::volatile_memory::{self, compute_offset, VolatileMemory, VolatileSlice};
+use crate::volatile_memory::{self, VolatileMemory, VolatileSlice};
 
 /// Error conditions that may arise when creating a new `MmapRegion` object.
 #[derive(Debug)]
@@ -413,17 +413,14 @@ impl<B: Bitmap> VolatileMemory for MmapRegion<B> {
         offset: usize,
         count: usize,
     ) -> volatile_memory::Result<VolatileSlice<BS<B>>> {
-        let end = compute_offset(offset, count)?;
-        if end > self.size {
-            return Err(volatile_memory::Error::OutOfBounds { addr: end });
-        }
+        let _ = self.compute_end_offset(offset, count)?;
 
         Ok(
             // SAFETY: Safe because we checked that offset + count was within our range and we only
             // ever hand out volatile accessors.
             unsafe {
                 VolatileSlice::with_bitmap(
-                    (self.addr as usize + offset) as *mut _,
+                    self.addr.add(offset),
                     count,
                     self.bitmap.slice_at(offset),
                 )

--- a/src/mmap_windows.rs
+++ b/src/mmap_windows.rs
@@ -210,11 +210,7 @@ impl<B: Bitmap> VolatileMemory for MmapRegion<B> {
         // Safe because we checked that offset + count was within our range and we only ever hand
         // out volatile accessors.
         Ok(unsafe {
-            VolatileSlice::with_bitmap(
-                (self.addr as usize + offset) as *mut _,
-                count,
-                self.bitmap.slice_at(offset),
-            )
+            VolatileSlice::with_bitmap(self.addr.add(offset), count, self.bitmap.slice_at(offset))
         })
     }
 }

--- a/src/mmap_windows.rs
+++ b/src/mmap_windows.rs
@@ -14,7 +14,7 @@ use winapi::um::errhandlingapi::GetLastError;
 
 use crate::bitmap::{Bitmap, BS};
 use crate::guest_memory::FileOffset;
-use crate::mmap::{AsSlice, NewBitmap};
+use crate::mmap::NewBitmap;
 use crate::volatile_memory::{self, compute_offset, VolatileMemory, VolatileSlice};
 
 #[allow(non_snake_case)]
@@ -187,21 +187,6 @@ impl<B: Bitmap> MmapRegion<B> {
     /// Returns a reference to the inner bitmap object.
     pub fn bitmap(&self) -> &B {
         &self.bitmap
-    }
-}
-
-impl<B> AsSlice for MmapRegion<B> {
-    unsafe fn as_slice(&self) -> &[u8] {
-        // This is safe because we mapped the area at addr ourselves, so this slice will not
-        // overflow. However, it is possible to alias.
-        std::slice::from_raw_parts(self.addr, self.size)
-    }
-
-    #[allow(clippy::mut_from_ref)]
-    unsafe fn as_mut_slice(&self) -> &mut [u8] {
-        // This is safe because we mapped the area at addr ourselves, so this slice will not
-        // overflow. However, it is possible to alias.
-        std::slice::from_raw_parts_mut(self.addr, self.size)
     }
 }
 


### PR DESCRIPTION
### Summary of the PR

Currently, vm-memory internally uses slices to operate on guest memory, in addition to providing methods for passing slices to guest memory to arbitrary user-code (via `read_from` and `write_to`). This PR makes sure that all internal operations on guest memory happen through pointers, to prevent accidental triggering of undefined behavior via violation of aliasing rules (either in rust-land, or due to the fact that the guest can modify its own memory at will while we hold references to guest memory). 

As a consequence of this PR, the unittests of vm-memory/src/volatile_memory.rs pass under miri

Addresses #45

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
