### PR TITLE
Xen/mmapv2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,14 @@ default = []
 backend-bitmap = []
 backend-mmap = []
 backend-atomic = ["arc-swap"]
+xen = ["backend-mmap", "bitflags", "vmm-sys-util"]
 
 [dependencies]
 libc = "0.2.39"
 arc-swap = { version = "1.0.0", optional = true }
+bitflags = { version = "1.0", optional = true }
 thiserror = "1.0.40"
+vmm-sys-util = { version = "0.11.0", optional = true }
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,33 @@ The detailed design of the `vm-memory` crate can be found [here](DESIGN.md).
 - Arch: x86, AMD64, ARM64
 - OS: Linux/Unix/Windows
 
+### Xen support
+
+Supporting Xen requires special handling while mapping the guest memory and
+hence a separate feature is added to the crate here: `xen`. Mapping the guest
+memory for Xen requires an `ioctl()` to be issued along with `mmap()` for the
+memory area. The arguments for the `ioctl()` are received via the `vhost-user`
+protocol's memory region area.
+
+Xen allows two different mapping models: `Foreign` and `Grant`.
+
+In `Foreign` mapping model, the entire guest address space is mapped at once, in
+advance. In `Grant` mapping model, the memory for few regions, like those
+representing the virtqueues, is mapped in advance. The rest of the memory
+regions are mapped (partially) only while accessing the buffers and the same is
+immediately deallocated after the buffer is accessed. Hence, special handling
+for the same in `VolatileMemory.rs`.
+
+In order to still support standard Unix memory regions, for special regions and
+testing, the Xen specific implementation here allows a third mapping type:
+`MmapXenFlags::UNIX`. This performs standard Unix memory mapping and the same is
+used for all tests in this crate.
+
+It was decided by the `rust-vmm` maintainers to keep the interface simple and
+build the crate for either standard Unix memory mapping or Xen, and not both.
+
+Xen is only supported for Unix platforms.
+
 ## Usage
 
 Add `vm-memory` as a dependency in `Cargo.toml`

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -6,7 +6,7 @@ extern crate criterion;
 
 pub use criterion::{black_box, criterion_group, criterion_main, Criterion};
 #[cfg(feature = "backend-mmap")]
-use vm_memory::{GuestAddress, GuestMemoryMmap};
+use vm_memory::{GuestAddress, GuestMemoryMmap, GuestMmapRange};
 
 mod guest_memory;
 mod mmap;
@@ -18,9 +18,13 @@ use volatile::benchmark_for_volatile;
 // Use this function with caution. It does not check against overflows
 // and `GuestMemoryMmap::from_ranges` errors.
 fn create_guest_memory_mmap(size: usize, count: u64) -> GuestMemoryMmap<()> {
-    let mut regions: Vec<(GuestAddress, usize)> = Vec::new();
+    let mut regions = Vec::new();
     for i in 0..count {
-        regions.push((GuestAddress(i * size as u64), size));
+        regions.push(GuestMmapRange::new(
+            GuestAddress(i * size as u64),
+            size,
+            None,
+        ));
     }
 
     GuestMemoryMmap::from_ranges(regions.as_slice()).unwrap()

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 91.9,
+  "coverage_score": 91.2,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap,backend-atomic,backend-bitmap"
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ mod mmap_windows;
 #[cfg(feature = "backend-mmap")]
 pub mod mmap;
 #[cfg(feature = "backend-mmap")]
-pub use mmap::{Error, GuestMemoryMmap, GuestRegionMmap, MmapRegion};
+pub use mmap::{Error, GuestMemoryMmap, GuestMmapRange, GuestRegionMmap, MmapRange, MmapRegion};
 
 pub mod volatile_memory;
 pub use volatile_memory::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,21 @@ pub use guest_memory::{
 #[cfg(all(feature = "backend-mmap", unix))]
 mod mmap_unix;
 
+#[cfg(all(feature = "xen", unix))]
+mod mmap_xen;
+
+#[cfg(all(feature = "backend-mmap", feature = "xen", unix))]
+pub use crate::mmap_xen::MmapXenFlags;
+
+#[cfg(all(feature = "backend-mmap", feature = "xen", unix))]
+use crate::mmap_xen::{MmapXen as MmapInfo, MmapXenSlice as MmapSlice};
+
+#[cfg(all(feature = "backend-mmap", not(feature = "xen"), unix))]
+use crate::mmap_unix::Mmap as MmapInfo;
+
+#[cfg(any(not(feature = "backend-mmap"), not(unix)))]
+type MmapInfo = std::marker::PhantomData<()>;
+
 #[cfg(all(feature = "backend-mmap", windows))]
 mod mmap_windows;
 

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -950,7 +950,7 @@ mod tests {
         let m =
             GuestRegionMmap::from_range(&GuestMmapRange::new(GuestAddress(0), 5, None)).unwrap();
         let s = m.get_slice(MemoryRegionAddress(2), 3).unwrap();
-        assert_eq!(s.as_ptr(), unsafe { m.as_ptr().offset(2) });
+        assert_eq!(s.ptr_guard().as_ptr(), unsafe { m.as_ptr().offset(2) });
     }
 
     #[test]

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -105,12 +105,47 @@ pub struct GuestMmapRange {
     pub(crate) size: usize,
     // File offset
     pub(crate) file: Option<FileOffset>,
+
+    // Xen mmap flags
+    #[cfg(all(feature = "xen", unix))]
+    pub(crate) mmap_flags: u32,
+    // Xen mmap data
+    #[cfg(all(feature = "xen", unix))]
+    pub(crate) mmap_data: u32,
 }
 
 impl GuestMmapRange {
     /// Creates a new instance of `GuestMmapRange`
     pub fn new(addr: GuestAddress, size: usize, file: Option<FileOffset>) -> Self {
-        Self { addr, size, file }
+        Self {
+            addr,
+            size,
+            file,
+
+            // Defaults to standard UNIX mapping. Use `with_xen()` for Xen specific mappings.
+            #[cfg(all(feature = "xen", unix))]
+            mmap_flags: super::MmapXenFlags::UNIX.bits(),
+            #[cfg(all(feature = "xen", unix))]
+            mmap_data: 0,
+        }
+    }
+
+    #[cfg(all(feature = "xen", unix))]
+    /// Creates a new instance of `GuestMmapRange` for Xen mappings.
+    pub fn with_xen(
+        addr: GuestAddress,
+        size: usize,
+        file: Option<FileOffset>,
+        mmap_flags: u32,
+        mmap_data: u32,
+    ) -> Self {
+        Self {
+            addr,
+            size,
+            file,
+            mmap_flags,
+            mmap_data,
+        }
     }
 }
 

--- a/src/mmap_windows.rs
+++ b/src/mmap_windows.rs
@@ -239,7 +239,12 @@ impl<B: Bitmap> VolatileMemory for MmapRegion<B> {
         // Safe because we checked that offset + count was within our range and we only ever hand
         // out volatile accessors.
         Ok(unsafe {
-            VolatileSlice::with_bitmap(self.addr.add(offset), count, self.bitmap.slice_at(offset))
+            VolatileSlice::with_bitmap(
+                self.addr.add(offset),
+                count,
+                self.bitmap.slice_at(offset),
+                None,
+            )
         })
     }
 }

--- a/src/mmap_xen.rs
+++ b/src/mmap_xen.rs
@@ -1,0 +1,800 @@
+// Copyright 2023 Linaro Ltd. All Rights Reserved.
+//          Viresh Kumar <viresh.kumar@linaro.org>
+//
+// Xen specific memory mapping implementations
+//
+// SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+
+//! Helper structure for working with mmap'ed memory regions on Xen.
+
+use bitflags::bitflags;
+use libc::{c_int, c_void, MAP_SHARED, _SC_PAGESIZE};
+use std::{io, mem::size_of, os::raw::c_ulong, os::unix::io::AsRawFd, ptr::null_mut};
+
+use vmm_sys_util::{
+    fam::{Error as FamError, FamStruct, FamStructWrapper},
+    generate_fam_struct_impl,
+    ioctl::{ioctl_expr, ioctl_with_ref, _IOC_NONE},
+};
+
+use crate::guest_memory::{FileOffset, GuestAddress};
+use crate::mmap_unix::{Error, Mmap as MmapUnix, Result};
+
+/// Error conditions that may arise with Xen APIs.
+#[derive(Debug, thiserror::Error)]
+pub enum XenError {
+    /// Invalid Xen mmap flags.
+    #[error("Invalid Xen Mmap flags: {0:x}")]
+    MmapFlags(u32),
+    /// Fam error.
+    #[error("Fam error: {0}")]
+    Fam(FamError),
+}
+
+fn page_size() -> u64 {
+    // SAFETY: Safe because this call just returns the page size and doesn't have any side effects.
+    unsafe { libc::sysconf(_SC_PAGESIZE) as u64 }
+}
+
+fn pages(size: usize) -> (usize, usize) {
+    let page_size = page_size() as usize;
+    let num = (size + page_size - 1) / page_size;
+
+    (num, page_size * num)
+}
+
+fn validate_file(file_offset: &Option<FileOffset>) -> Result<(i32, u64)> {
+    let (fd, f_offset) = match file_offset {
+        Some(file) => (file.file().as_raw_fd(), file.start()),
+        None => return Err(Error::InvalidFileOffset),
+    };
+
+    // We don't allow file offsets with Xen foreign mappings.
+    if f_offset != 0 {
+        return Err(Error::InvalidOffsetLength);
+    }
+
+    Ok((fd, f_offset))
+}
+
+// Bit mask for the vhost-user xen mmap message.
+bitflags! {
+    /// Flags for the Xen mmap message.
+    pub struct MmapXenFlags: u32 {
+        /// Standard Unix memory mapping.
+        const UNIX = 0x0;
+        /// Xen foreign memory (accessed via /dev/privcmd).
+        const FOREIGN = 0x1;
+        /// Xen grant memory (accessed via /dev/gntdev).
+        const GRANT = 0x2;
+        /// Xen no advance mapping.
+        const NO_ADVANCE_MAP = 0x8;
+        /// All valid mappings.
+        const ALL = Self::FOREIGN.bits() | Self::GRANT.bits();
+    }
+}
+
+impl MmapXenFlags {
+    /// Mmap flags are valid.
+    pub fn is_valid(&self) -> bool {
+        // Only one of UNIX, FOREIGN or GRANT should be set and mmap_in_advance() should be true
+        // with FOREIGN and UNIX.
+        if self.is_grant() {
+            !self.is_foreign()
+        } else if self.is_foreign() || self.is_unix() {
+            self.mmap_in_advance()
+        } else {
+            false
+        }
+    }
+
+    /// Is standard Unix memory.
+    pub fn is_unix(&self) -> bool {
+        self.bits() == Self::UNIX.bits()
+    }
+
+    /// Is xen foreign memory.
+    pub fn is_foreign(&self) -> bool {
+        self.contains(Self::FOREIGN)
+    }
+
+    /// Is xen grant memory.
+    pub fn is_grant(&self) -> bool {
+        self.contains(Self::GRANT)
+    }
+
+    /// Can mmap entire region in advance.
+    pub fn mmap_in_advance(&self) -> bool {
+        !self.contains(Self::NO_ADVANCE_MAP)
+    }
+}
+
+// Xen Foreign memory mapping interface.
+trait MmapXenTrait: std::fmt::Debug {
+    #[cfg(test)]
+    fn owned(&self) -> bool {
+        true
+    }
+
+    fn mmap(
+        &mut self,
+        size: usize,
+        prot: i32,
+        flags: i32,
+        file_offset: &Option<FileOffset>,
+    ) -> Result<()>;
+
+    #[allow(unused_variables)]
+    fn mmap_slice(&self, addr: *const u8, prot: i32, len: usize) -> Result<MmapXenSlice> {
+        panic!();
+    }
+
+    fn addr(&self) -> *mut u8;
+
+    fn mmap_in_advance(&self) -> bool;
+
+    fn raw_mmap(&mut self, _addr: *mut u8) {
+        panic!();
+    }
+}
+
+// Standard Unix memory mapping.
+#[derive(Clone, Debug, PartialEq)]
+struct MmapXenUnix(Option<MmapUnix>);
+
+impl MmapXenUnix {
+    fn new() -> Self {
+        Self(None)
+    }
+}
+
+impl MmapXenTrait for MmapXenUnix {
+    fn mmap(
+        &mut self,
+        size: usize,
+        prot: i32,
+        flags: i32,
+        file_offset: &Option<FileOffset>,
+    ) -> Result<()> {
+        self.0 = Some(MmapUnix::with_checks(size, prot, flags, file_offset)?);
+        Ok(())
+    }
+
+    fn addr(&self) -> *mut u8 {
+        if let Some(ref mmap) = self.0 {
+            mmap.addr()
+        } else {
+            null_mut()
+        }
+    }
+
+    fn raw_mmap(&mut self, addr: *mut u8) {
+        self.0 = Some(MmapUnix::raw(addr));
+    }
+
+    fn mmap_in_advance(&self) -> bool {
+        self.0.as_ref().unwrap().mmap_in_advance()
+    }
+
+    #[cfg(test)]
+    fn owned(&self) -> bool {
+        self.0.as_ref().unwrap().owned()
+    }
+}
+
+// Privcmd mmap batch v2 command
+//
+// include/uapi/xen/privcmd.h: `privcmd_mmapbatch_v2`
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+struct PrivCmdMmapBatchV2 {
+    // number of pages to populate
+    num: u32,
+    // target domain
+    domid: u16,
+    // virtual address
+    addr: *mut c_void,
+    // array of mfns
+    arr: *const u64,
+    // array of error codes
+    err: *mut c_int,
+}
+
+const XEN_PRIVCMD_TYPE: u32 = 'P' as u32;
+
+// #define IOCTL_PRIVCMD_MMAPBATCH_V2 _IOC(_IOC_NONE, 'P', 4, sizeof(privcmd_mmapbatch_v2_t))
+fn ioctl_privcmd_mmapbatch_v2() -> c_ulong {
+    ioctl_expr(
+        _IOC_NONE,
+        XEN_PRIVCMD_TYPE,
+        4,
+        size_of::<PrivCmdMmapBatchV2>() as u32,
+    )
+}
+
+// Xen foreign memory specific implementation.
+#[derive(Clone, Debug, PartialEq)]
+struct MmapXenForeign {
+    domid: u32,
+    guest_base: GuestAddress,
+    mmap: Option<MmapUnix>,
+    fd: i32,
+}
+
+impl AsRawFd for MmapXenForeign {
+    fn as_raw_fd(&self) -> i32 {
+        self.fd
+    }
+}
+
+impl MmapXenForeign {
+    fn new(domid: u32, guest_base: GuestAddress) -> Self {
+        Self {
+            domid,
+            guest_base,
+            mmap: None,
+            fd: 0,
+        }
+    }
+
+    // Ioctl to pass additional information to mmap infrastructure of privcmd driver.
+    fn ioctl(&self, count: usize, addr: *mut u8) -> Result<()> {
+        let base = self.guest_base.0 / page_size();
+
+        let mut pfn = Vec::with_capacity(count);
+        for i in 0..count {
+            pfn.push(base + i as u64);
+        }
+
+        let mut err: Vec<c_int> = vec![0; count];
+
+        let map = PrivCmdMmapBatchV2 {
+            num: count as u32,
+            domid: self.domid as u16,
+            addr: addr as *mut c_void,
+            arr: pfn.as_ptr(),
+            err: err.as_mut_ptr(),
+        };
+
+        // SAFETY: This is safe because the ioctl guarantees to not access memory beyond `map`.
+        let ret = unsafe { ioctl_with_ref(self, ioctl_privcmd_mmapbatch_v2(), &map) };
+
+        if ret == 0 {
+            Ok(())
+        } else {
+            Err(Error::Mmap(io::Error::last_os_error()))
+        }
+    }
+}
+
+impl MmapXenTrait for MmapXenForeign {
+    // Maps the entire guest memory space at once.
+    fn mmap(
+        &mut self,
+        size: usize,
+        prot: i32,
+        flags: i32,
+        file_offset: &Option<FileOffset>,
+    ) -> Result<()> {
+        let (fd, f_offset) = validate_file(file_offset)?;
+        let (count, size) = pages(size);
+        let mmap = MmapUnix::new(size, prot, flags | MAP_SHARED, fd, f_offset)?;
+
+        self.fd = fd;
+        self.ioctl(count, mmap.addr())?;
+        self.mmap = Some(mmap);
+
+        Ok(())
+    }
+
+    fn addr(&self) -> *mut u8 {
+        if let Some(ref mmap) = self.mmap {
+            mmap.addr()
+        } else {
+            null_mut()
+        }
+    }
+
+    fn mmap_in_advance(&self) -> bool {
+        true
+    }
+}
+
+// Xen Grant memory mapping interface.
+
+const XEN_GRANT_ADDR_OFF: u64 = 1 << 63;
+
+// Grant reference
+//
+// include/uapi/xen/gntdev.h: `ioctl_gntdev_grant_ref`
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+struct GntDevGrantRef {
+    // The domain ID of the grant to be mapped.
+    domid: u32,
+    // The grant reference of the grant to be mapped.
+    reference: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, PartialEq, Eq)]
+struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
+impl<T> __IncompleteArrayField<T> {
+    #[inline]
+    pub unsafe fn as_ptr(&self) -> *const T {
+        self as *const __IncompleteArrayField<T> as *const T
+    }
+    #[inline]
+    pub unsafe fn as_mut_ptr(&mut self) -> *mut T {
+        self as *mut __IncompleteArrayField<T> as *mut T
+    }
+    #[inline]
+    pub unsafe fn as_slice(&self, len: usize) -> &[T] {
+        ::std::slice::from_raw_parts(self.as_ptr(), len)
+    }
+    #[inline]
+    pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
+        ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+    }
+}
+
+// Grant dev mapping reference
+//
+// include/uapi/xen/gntdev.h: `ioctl_gntdev_map_grant_ref`
+#[repr(C)]
+#[derive(Debug, Default)]
+struct GntDevMapGrantRef {
+    // The number of grants to be mapped.
+    count: u32,
+    // Unused padding
+    pad: u32,
+    // The offset to be used on a subsequent call to mmap().
+    index: u64,
+    // Array of grant references, of size @count.
+    refs: __IncompleteArrayField<GntDevGrantRef>,
+}
+
+generate_fam_struct_impl!(
+    GntDevMapGrantRef,
+    GntDevGrantRef,
+    refs,
+    u32,
+    count,
+    usize::MAX
+);
+
+type GntDevMapGrantRefWrapper = FamStructWrapper<GntDevMapGrantRef>;
+
+impl GntDevMapGrantRef {
+    fn new(domid: u32, base: u32, count: usize) -> Result<GntDevMapGrantRefWrapper> {
+        let mut wrapper = GntDevMapGrantRefWrapper::new(count)
+            .map_err(XenError::Fam)
+            .map_err(Error::Xen)?;
+        let refs = wrapper.as_mut_slice();
+
+        // GntDevMapGrantRef's pad and index are initialized to 0 by Fam layer.
+        for (i, r) in refs.iter_mut().enumerate().take(count) {
+            r.domid = domid;
+            r.reference = base + i as u32;
+        }
+
+        Ok(wrapper)
+    }
+}
+
+// Grant dev un-mapping reference
+//
+// include/uapi/xen/gntdev.h: `ioctl_gntdev_unmap_grant_ref`
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+struct GntDevUnmapGrantRef {
+    // The offset returned by the map operation.
+    index: u64,
+    // The number of grants to be unmapped.
+    count: u32,
+    // Unused padding
+    pad: u32,
+}
+
+impl GntDevUnmapGrantRef {
+    fn new(index: u64, count: u32) -> Self {
+        Self {
+            index,
+            count,
+            pad: 0,
+        }
+    }
+}
+
+const XEN_GNTDEV_TYPE: u32 = 'G' as u32;
+
+// #define IOCTL_GNTDEV_MAP_GRANT_REF _IOC(_IOC_NONE, 'G', 0, sizeof(ioctl_gntdev_map_grant_ref))
+fn ioctl_gntdev_map_grant_ref() -> c_ulong {
+    ioctl_expr(
+        _IOC_NONE,
+        XEN_GNTDEV_TYPE,
+        0,
+        (size_of::<GntDevMapGrantRef>() + size_of::<GntDevGrantRef>()) as u32,
+    )
+}
+
+// #define IOCTL_GNTDEV_UNMAP_GRANT_REF _IOC(_IOC_NONE, 'G', 1, sizeof(struct ioctl_gntdev_unmap_grant_ref))
+fn ioctl_gntdev_unmap_grant_ref() -> c_ulong {
+    ioctl_expr(
+        _IOC_NONE,
+        XEN_GNTDEV_TYPE,
+        1,
+        size_of::<GntDevUnmapGrantRef>() as u32,
+    )
+}
+
+// Xen grant memory specific implementation.
+#[derive(Clone, Debug, PartialEq)]
+struct MmapXenGrant {
+    guest_base: GuestAddress,
+    mmap: Option<MmapUnix>,
+    flags: i32,
+    fd: i32,
+    size: usize,
+    index: u64,
+    domid: u32,
+    mmap_in_advance: bool,
+}
+
+impl AsRawFd for MmapXenGrant {
+    fn as_raw_fd(&self) -> i32 {
+        self.fd
+    }
+}
+
+impl MmapXenGrant {
+    fn new(domid: u32, guest_base: GuestAddress, flags: MmapXenFlags) -> Self {
+        Self {
+            guest_base,
+            mmap: None,
+            flags: 0,
+            fd: 0,
+            size: 0,
+            index: 0,
+            domid,
+            mmap_in_advance: flags.mmap_in_advance(),
+        }
+    }
+
+    fn mmap_ioctl(&self, addr: GuestAddress, count: usize) -> Result<u64> {
+        let base = ((addr.0 & !XEN_GRANT_ADDR_OFF) / page_size()) as u32;
+        let wrapper = GntDevMapGrantRef::new(self.domid, base, count)?;
+        let reference = wrapper.as_fam_struct_ref();
+
+        // SAFETY: This is safe because the ioctl guarantees to not access memory beyond reference.
+        let ret = unsafe { ioctl_with_ref(self, ioctl_gntdev_map_grant_ref(), reference) };
+
+        if ret == 0 {
+            Ok(reference.index)
+        } else {
+            Err(Error::Mmap(io::Error::last_os_error()))
+        }
+    }
+
+    fn unmap_ioctl(&self, count: u32, index: u64) -> Result<()> {
+        let unmap = GntDevUnmapGrantRef::new(index, count);
+
+        // SAFETY: This is safe because the ioctl guarantees to not access memory beyond unmap.
+        let ret = unsafe { ioctl_with_ref(self, ioctl_gntdev_unmap_grant_ref(), &unmap) };
+
+        if ret == 0 {
+            Ok(())
+        } else {
+            Err(Error::Mmap(io::Error::last_os_error()))
+        }
+    }
+
+    fn mmap_range(&self, addr: GuestAddress, size: usize, prot: i32) -> Result<(MmapUnix, u64)> {
+        let (count, size) = pages(size);
+        let index = self.mmap_ioctl(addr, count)?;
+        let mmap = MmapUnix::new(size, prot, self.flags, self.fd, index)?;
+
+        Ok((mmap, index))
+    }
+
+    fn unmap_range(&self, mmap: MmapUnix, size: usize, index: u64) {
+        let (count, _) = pages(size);
+
+        // Unmap the address first.
+        drop(mmap);
+        self.unmap_ioctl(count as u32, index).unwrap();
+    }
+}
+
+impl MmapXenTrait for MmapXenGrant {
+    // Maps the memory if mmap_in_advance() is set.
+    fn mmap(
+        &mut self,
+        size: usize,
+        prot: i32,
+        flags: i32,
+        file_offset: &Option<FileOffset>,
+    ) -> Result<()> {
+        let (fd, _) = validate_file(file_offset)?;
+
+        // Save fd and flags for later use.
+        self.fd = fd;
+        self.flags = flags;
+
+        // Region can't be mapped in advance, partial mapping will be done later via
+        // `MmapXenSlice`.
+        if self.mmap_in_advance() {
+            let (mmap, index) = self.mmap_range(self.guest_base, size, prot)?;
+            self.mmap = Some(mmap);
+            self.index = index;
+            self.size = size;
+        }
+
+        Ok(())
+    }
+
+    // Maps a slice out of the entire region.
+    fn mmap_slice(&self, addr: *const u8, prot: i32, len: usize) -> Result<MmapXenSlice> {
+        assert!(!self.mmap_in_advance());
+        MmapXenSlice::new_with(self.clone(), addr as usize, prot, len)
+    }
+
+    fn addr(&self) -> *mut u8 {
+        if let Some(ref mmap) = self.mmap {
+            mmap.addr()
+        } else {
+            null_mut()
+        }
+    }
+
+    fn mmap_in_advance(&self) -> bool {
+        self.mmap_in_advance
+    }
+}
+
+impl Drop for MmapXenGrant {
+    fn drop(&mut self) {
+        if let Some(mmap) = self.mmap.take() {
+            self.unmap_range(mmap, self.size, self.index);
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct MmapXenSlice {
+    grant: Option<MmapXenGrant>,
+    mmap: Option<MmapUnix>,
+    addr: *mut u8,
+    size: usize,
+    index: u64,
+}
+
+impl MmapXenSlice {
+    pub fn new(addr: *mut u8) -> Self {
+        Self {
+            grant: None,
+            mmap: None,
+            addr,
+            size: 0,
+            index: 0,
+        }
+    }
+
+    fn new_with(grant: MmapXenGrant, offset: usize, prot: i32, size: usize) -> Result<Self> {
+        let page_size = page_size() as usize;
+        let page_base: usize = (offset / page_size) * page_size;
+        let offset = offset - page_base;
+        let size = offset + size;
+
+        let addr = grant.guest_base.0 + page_base as u64;
+        let (mmap, index) = grant.mmap_range(GuestAddress(addr), size, prot)?;
+
+        // SAFETY: We have already mapped the range including offset.
+        let addr = unsafe { mmap.addr().add(offset) };
+
+        Ok(Self {
+            grant: Some(grant),
+            mmap: Some(mmap),
+            addr,
+            size,
+            index,
+        })
+    }
+
+    // Mapped address for the region.
+    pub fn addr(&self) -> *mut u8 {
+        self.addr
+    }
+}
+
+impl Drop for MmapXenSlice {
+    fn drop(&mut self) {
+        // Unmaps memory automatically once this instance goes out of scope.
+        if let Some(mmap) = self.mmap.take() {
+            self.grant
+                .as_ref()
+                .unwrap()
+                .unmap_range(mmap, self.size, self.index);
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct MmapXen {
+    xen_flags: MmapXenFlags,
+    domid: u32,
+    mmap: Box<dyn MmapXenTrait>,
+}
+
+impl MmapXen {
+    pub fn new(guest_base: GuestAddress, flags: u32, domid: u32) -> Result<Self> {
+        let xen_flags = match MmapXenFlags::from_bits(flags) {
+            Some(flags) => flags,
+            None => return Err(Error::Xen(XenError::MmapFlags(flags))),
+        };
+
+        if !xen_flags.is_valid() {
+            return Err(Error::Xen(XenError::MmapFlags(xen_flags.bits())));
+        }
+
+        Ok(Self {
+            xen_flags,
+            domid,
+            mmap: if xen_flags.is_foreign() {
+                Box::new(MmapXenForeign::new(domid, guest_base))
+            } else if xen_flags.is_grant() {
+                Box::new(MmapXenGrant::new(domid, guest_base, xen_flags))
+            } else {
+                Box::new(MmapXenUnix::new())
+            },
+        })
+    }
+
+    pub fn addr(&self) -> *mut u8 {
+        self.mmap.addr()
+    }
+
+    pub fn flags(&self) -> u32 {
+        self.xen_flags.bits()
+    }
+
+    pub fn data(&self) -> u32 {
+        self.domid
+    }
+
+    pub fn mmap_in_advance(&self) -> bool {
+        self.mmap.mmap_in_advance()
+    }
+
+    pub fn raw_mmap(&mut self, addr: *mut u8) {
+        self.mmap.raw_mmap(addr);
+    }
+
+    pub fn mmap(
+        &mut self,
+        size: usize,
+        prot: i32,
+        flags: i32,
+        file_offset: &Option<FileOffset>,
+    ) -> Result<()> {
+        self.mmap.mmap(size, prot, flags, file_offset)
+    }
+
+    // Translates the address.
+    pub(crate) fn mmap_slice(
+        &self,
+        addr: *const u8,
+        prot: i32,
+        len: usize,
+    ) -> Result<MmapXenSlice> {
+        self.mmap.mmap_slice(addr, prot, len)
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    #![allow(clippy::undocumented_unsafe_blocks)]
+
+    use super::*;
+    use vmm_sys_util::tempfile::TempFile;
+
+    impl MmapXen {
+        pub fn owned(&self) -> bool {
+            self.mmap.owned()
+        }
+    }
+
+    #[test]
+    fn test_mmap_xen_failures() {
+        let addr = GuestAddress(0x1000);
+        let domid = 1;
+
+        // Failures
+        let flags = 16;
+        let r = MmapXen::new(addr, flags, domid);
+        assert_eq!(
+            format!("{:?}", r.unwrap_err()),
+            format!("Xen(MmapFlags({}))", flags),
+        );
+
+        let flag = MmapXenFlags::FOREIGN.bits() | MmapXenFlags::GRANT.bits();
+        let r = MmapXen::new(addr, flag, domid);
+        assert_eq!(
+            format!("{:?}", r.unwrap_err()),
+            format!("Xen(MmapFlags({:x}))", MmapXenFlags::ALL.bits()),
+        );
+
+        let flag = MmapXenFlags::FOREIGN.bits() | MmapXenFlags::NO_ADVANCE_MAP.bits();
+        let r = MmapXen::new(addr, flag, domid);
+        assert_eq!(
+            format!("{:?}", r.unwrap_err()),
+            format!(
+                "Xen(MmapFlags({:x}))",
+                MmapXenFlags::NO_ADVANCE_MAP.bits() | MmapXenFlags::FOREIGN.bits(),
+            ),
+        );
+    }
+
+    #[test]
+    fn test_foreign_map_ioctl_failure() {
+        let addr = GuestAddress(0x1000);
+        let domid = 1;
+        let mut map = MmapXenForeign::new(domid, addr);
+        let file = TempFile::new().unwrap().into_file();
+        map.fd = file.as_raw_fd();
+        assert!(map.ioctl(0x1000, null_mut()).is_err());
+    }
+
+    #[test]
+    fn test_foreign_map() {
+        let addr = GuestAddress(0x1000);
+        let domid = 1;
+
+        let map = MmapXenForeign::new(domid, addr);
+
+        assert_eq!(map.domid, domid);
+        assert_eq!(map.guest_base, addr);
+        assert_eq!(map.addr(), null_mut());
+        assert_eq!(map.fd, 0);
+        assert!(map.mmap_in_advance());
+    }
+
+    #[test]
+    fn test_grant_map_ioctl_failure() {
+        let addr = GuestAddress(0x1000);
+        let domid = 1;
+        let flag = MmapXenFlags::NO_ADVANCE_MAP;
+        let mut map = MmapXenGrant::new(domid, addr, flag);
+        let file = TempFile::new().unwrap().into_file();
+        map.fd = file.as_raw_fd();
+        assert!(map.mmap_ioctl(addr, 0x1000).is_err());
+    }
+
+    #[test]
+    fn test_grant_map() {
+        let addr = GuestAddress(0x1000);
+        let domid = 1;
+        let flag = MmapXenFlags::NO_ADVANCE_MAP;
+        let map = MmapXenGrant::new(domid, addr, flag);
+
+        assert_eq!(map.guest_base, addr);
+        assert_eq!(map.flags, 0);
+        assert_eq!(map.fd, 0);
+        assert_eq!(map.size, 0);
+        assert_eq!(map.index, 0);
+        assert_eq!(map.domid, domid);
+        assert!(!map.mmap_in_advance());
+
+        let map = MmapXenGrant::new(domid, addr, MmapXenFlags::empty());
+        assert!(map.mmap_in_advance());
+    }
+
+    #[test]
+    fn test_grant_ref_alloc() {
+        let wrapper = GntDevMapGrantRef::new(0, 0x1000, 0x100).unwrap();
+        let r = wrapper.as_fam_struct_ref();
+        assert_eq!(r.count, 0x100);
+        assert_eq!(r.pad, 0);
+        assert_eq!(r.index, 0);
+    }
+}

--- a/src/volatile_memory.rs
+++ b/src/volatile_memory.rs
@@ -35,9 +35,12 @@ use std::usize;
 
 use crate::atomic_integer::AtomicInteger;
 use crate::bitmap::{Bitmap, BitmapSlice, BS};
-use crate::{AtomicAccess, ByteValued, Bytes};
+use crate::{AtomicAccess, ByteValued, Bytes, MmapInfo};
 
 use copy_slice_impl::{copy_from_volatile_slice, copy_to_volatile_slice};
+
+#[cfg(all(feature = "xen", unix))]
+use copy_slice_impl::mmap_slice;
 
 /// `VolatileMemory` related errors.
 #[allow(missing_docs)]
@@ -115,7 +118,13 @@ pub trait VolatileMemory {
         let slice = self.get_slice(offset, size_of::<T>())?;
         // SAFETY: This is safe because the pointer is range-checked by get_slice, and
         // the lifetime is the same as self.
-        unsafe { Ok(VolatileRef::with_bitmap(slice.addr, slice.bitmap)) }
+        unsafe {
+            Ok(VolatileRef::with_bitmap(
+                slice.addr,
+                slice.bitmap,
+                slice.mmap,
+            ))
+        }
     }
 
     /// Returns a [`VolatileArrayRef`](struct.VolatileArrayRef.html) of `n` elements starting at
@@ -136,7 +145,14 @@ pub trait VolatileMemory {
         let slice = self.get_slice(offset, nbytes as usize)?;
         // SAFETY: This is safe because the pointer is range-checked by get_slice, and
         // the lifetime is the same as self.
-        unsafe { Ok(VolatileArrayRef::with_bitmap(slice.addr, n, slice.bitmap)) }
+        unsafe {
+            Ok(VolatileArrayRef::with_bitmap(
+                slice.addr,
+                n,
+                slice.bitmap,
+                slice.mmap,
+            ))
+        }
     }
 
     /// Returns a reference to an instance of `T` at `offset`.
@@ -225,7 +241,7 @@ pub struct VolatileSlice<'a, B = ()> {
     addr: *mut u8,
     size: usize,
     bitmap: B,
-    phantom: PhantomData<&'a u8>,
+    mmap: Option<&'a MmapInfo>,
 }
 
 impl<'a> VolatileSlice<'a, ()> {
@@ -238,7 +254,7 @@ impl<'a> VolatileSlice<'a, ()> {
     /// must also guarantee that all other users of the given chunk of memory are using volatile
     /// accesses.
     pub unsafe fn new(addr: *mut u8, size: usize) -> VolatileSlice<'a> {
-        Self::with_bitmap(addr, size, ())
+        Self::with_bitmap(addr, size, (), None)
     }
 }
 
@@ -252,12 +268,17 @@ impl<'a, B: BitmapSlice> VolatileSlice<'a, B> {
     /// and is available for the duration of the lifetime of the new `VolatileSlice`. The caller
     /// must also guarantee that all other users of the given chunk of memory are using volatile
     /// accesses.
-    pub unsafe fn with_bitmap(addr: *mut u8, size: usize, bitmap: B) -> VolatileSlice<'a, B> {
+    pub unsafe fn with_bitmap(
+        addr: *mut u8,
+        size: usize,
+        bitmap: B,
+        mmap: Option<&'a MmapInfo>,
+    ) -> VolatileSlice<'a, B> {
         VolatileSlice {
             addr,
             size,
             bitmap,
-            phantom: PhantomData,
+            mmap,
         }
     }
 
@@ -302,8 +323,9 @@ impl<'a, B: BitmapSlice> VolatileSlice<'a, B> {
     /// ```
     pub fn split_at(&self, mid: usize) -> Result<(Self, Self)> {
         let end = self.offset(mid)?;
-        // SAFETY: safe because self.offset() already checked the bounds
-        let start = unsafe { VolatileSlice::with_bitmap(self.addr, mid, self.bitmap.clone()) };
+        let start =
+            // SAFETY: safe because self.offset() already checked the bounds
+            unsafe { VolatileSlice::with_bitmap(self.addr, mid, self.bitmap.clone(), self.mmap) };
 
         Ok((start, end))
     }
@@ -323,6 +345,7 @@ impl<'a, B: BitmapSlice> VolatileSlice<'a, B> {
                 self.as_ptr().add(offset),
                 count,
                 self.bitmap.slice_at(offset),
+                self.mmap,
             ))
         }
     }
@@ -350,6 +373,7 @@ impl<'a, B: BitmapSlice> VolatileSlice<'a, B> {
                 self.addr.add(count),
                 new_size,
                 self.bitmap.slice_at(count),
+                self.mmap,
             ))
         }
     }
@@ -851,6 +875,7 @@ impl<B: BitmapSlice> VolatileMemory for VolatileSlice<'_, B> {
                     self.addr.add(offset),
                     count,
                     self.bitmap.slice_at(offset),
+                    self.mmap,
                 )
             },
         )
@@ -876,7 +901,7 @@ impl<B: BitmapSlice> VolatileMemory for VolatileSlice<'_, B> {
 pub struct VolatileRef<'a, T, B = ()> {
     addr: *mut Packed<T>,
     bitmap: B,
-    phantom: PhantomData<&'a T>,
+    mmap: Option<&'a MmapInfo>,
 }
 
 impl<'a, T> VolatileRef<'a, T, ()>
@@ -892,7 +917,7 @@ where
     /// must also guarantee that all other users of the given chunk of memory are using volatile
     /// accesses.
     pub unsafe fn new(addr: *mut u8) -> Self {
-        Self::with_bitmap(addr, ())
+        Self::with_bitmap(addr, (), None)
     }
 }
 
@@ -911,11 +936,11 @@ where
     /// `T` and is available for the duration of the lifetime of the new `VolatileRef`. The caller
     /// must also guarantee that all other users of the given chunk of memory are using volatile
     /// accesses.
-    pub unsafe fn with_bitmap(addr: *mut u8, bitmap: B) -> Self {
+    pub unsafe fn with_bitmap(addr: *mut u8, bitmap: B, mmap: Option<&'a MmapInfo>) -> Self {
         VolatileRef {
             addr: addr as *mut Packed<T>,
             bitmap,
-            phantom: PhantomData,
+            mmap,
         }
     }
 
@@ -949,19 +974,43 @@ where
     /// Does a volatile write of the value `v` to the address of this ref.
     #[inline(always)]
     pub fn store(&self, v: T) {
+        #[cfg(not(all(feature = "xen", unix)))]
+        let addr = self.addr;
+
+        #[cfg(all(feature = "xen", unix))]
+        let (addr, _slice) = {
+            let slice = mmap_slice(
+                self.mmap,
+                self.addr as *mut u8,
+                self.len(),
+                libc::PROT_WRITE,
+            );
+
+            (slice.addr() as *mut Packed<T>, slice)
+        };
+
         // SAFETY: Safe because we checked the address and size when creating this VolatileRef.
-        unsafe { write_volatile(self.addr, Packed::<T>(v)) };
-        self.bitmap.mark_dirty(0, size_of::<T>())
+        unsafe { write_volatile(addr, Packed::<T>(v)) };
+        self.bitmap.mark_dirty(0, self.len())
     }
 
     /// Does a volatile read of the value at the address of this ref.
     #[inline(always)]
     pub fn load(&self) -> T {
+        #[cfg(not(all(feature = "xen", unix)))]
+        let addr = self.addr;
+
+        #[cfg(all(feature = "xen", unix))]
+        let (addr, _slice) = {
+            let slice = mmap_slice(self.mmap, self.addr as *mut u8, self.len(), libc::PROT_READ);
+            (slice.addr() as *mut Packed<T>, slice)
+        };
+
         // SAFETY: Safe because we checked the address and size when creating this VolatileRef.
         // For the purposes of demonstrating why read_volatile is necessary, try replacing the code
         // in this function with the commented code below and running `cargo test --release`.
         // unsafe { *(self.addr as *const T) }
-        unsafe { read_volatile(self.addr).0 }
+        unsafe { read_volatile(addr).0 }
     }
 
     /// Converts this to a [`VolatileSlice`](struct.VolatileSlice.html) with the same size and
@@ -969,7 +1018,12 @@ where
     pub fn to_slice(&self) -> VolatileSlice<'a, B> {
         // SAFETY: Safe because we checked the address and size when creating this VolatileRef.
         unsafe {
-            VolatileSlice::with_bitmap(self.addr as *mut u8, size_of::<T>(), self.bitmap.clone())
+            VolatileSlice::with_bitmap(
+                self.addr as *mut u8,
+                size_of::<T>(),
+                self.bitmap.clone(),
+                self.mmap,
+            )
         }
     }
 }
@@ -995,6 +1049,7 @@ pub struct VolatileArrayRef<'a, T, B = ()> {
     nelem: usize,
     bitmap: B,
     phantom: PhantomData<&'a T>,
+    mmap: Option<&'a MmapInfo>,
 }
 
 impl<'a, T> VolatileArrayRef<'a, T>
@@ -1011,7 +1066,7 @@ where
     /// `VolatileRef`. The caller must also guarantee that all other users of the given chunk of
     /// memory are using volatile accesses.
     pub unsafe fn new(addr: *mut u8, nelem: usize) -> Self {
-        Self::with_bitmap(addr, nelem, ())
+        Self::with_bitmap(addr, nelem, (), None)
     }
 }
 
@@ -1029,12 +1084,18 @@ where
     /// `nelem` values of type `T` and is available for the duration of the lifetime of the new
     /// `VolatileRef`. The caller must also guarantee that all other users of the given chunk of
     /// memory are using volatile accesses.
-    pub unsafe fn with_bitmap(addr: *mut u8, nelem: usize, bitmap: B) -> Self {
+    pub unsafe fn with_bitmap(
+        addr: *mut u8,
+        nelem: usize,
+        bitmap: B,
+        mmap: Option<&'a MmapInfo>,
+    ) -> Self {
         VolatileArrayRef {
             addr,
             nelem,
             bitmap,
             phantom: PhantomData,
+            mmap,
         }
     }
 
@@ -1101,6 +1162,7 @@ where
                 self.addr,
                 self.nelem * self.element_size(),
                 self.bitmap.clone(),
+                self.mmap,
             )
         }
     }
@@ -1118,7 +1180,7 @@ where
             // byteofs must fit in an isize as it was checked in get_array_ref.
             let byteofs = (self.element_size() * index) as isize;
             let ptr = self.as_ptr().offset(byteofs);
-            VolatileRef::with_bitmap(ptr, self.bitmap.slice_at(byteofs as usize))
+            VolatileRef::with_bitmap(ptr, self.bitmap.slice_at(byteofs as usize), self.mmap)
         }
     }
 
@@ -1172,20 +1234,32 @@ where
             };
         }
 
-        let mut addr = self.addr;
-        let mut i = 0;
+        #[cfg(not(all(feature = "xen", unix)))]
+        let mut addr = self.addr as *const Packed<T>;
+
+        #[cfg(all(feature = "xen", unix))]
+        let (mut addr, _slice) = {
+            let len = buf.len().min(self.len()) * self.element_size();
+            let slice = mmap_slice(self.mmap, self.addr, len, libc::PROT_READ);
+
+            (slice.addr() as *const Packed<T>, slice)
+        };
+
+        let start = addr;
+
         for v in buf.iter_mut().take(self.len()) {
             // SAFETY: read_volatile is safe because the pointers are range-checked when
             // the slices are created, and they never escape the VolatileSlices.
             // ptr::add is safe because get_array_ref() validated that
             // size_of::<T>() * self.len() fits in an isize.
             unsafe {
-                *v = read_volatile(addr as *const Packed<T>).0;
-                addr = addr.add(self.element_size());
-            };
-            i += 1;
+                *v = read_volatile(addr).0;
+                addr = addr.add(1);
+            }
         }
-        i
+
+        // SAFETY: It is guaranteed that start and addr point to the regions of the same slice.
+        unsafe { addr.offset_from(start) as usize }
     }
 
     /// Copies as many bytes as possible from this slice to the provided `slice`.
@@ -1255,20 +1329,31 @@ where
             // - size is always a multiple of alignment, so treating *const T as *const u8 is fine
             unsafe { copy_to_volatile_slice(&destination, buf.as_ptr() as *const u8, total) };
         } else {
-            let mut addr = self.addr;
+            #[cfg(not(all(feature = "xen", unix)))]
+            let mut addr = self.addr as *mut Packed<T>;
+
+            #[cfg(all(feature = "xen", unix))]
+            let (mut addr, _slice) = {
+                let len = buf.len().min(self.len()) * self.element_size();
+                let slice = mmap_slice(self.mmap, self.addr, len, libc::PROT_WRITE);
+
+                (slice.addr() as *mut Packed<T>, slice)
+            };
+
+            let start = addr;
+
             for &v in buf.iter().take(self.len()) {
                 // SAFETY: write_volatile is safe because the pointers are range-checked when
                 // the slices are created, and they never escape the VolatileSlices.
                 // ptr::add is safe because get_array_ref() validated that
                 // size_of::<T>() * self.len() fits in an isize.
                 unsafe {
-                    write_volatile(addr as *mut Packed<T>, Packed::<T>(v));
-                    addr = addr.add(self.element_size());
+                    write_volatile(addr, Packed::<T>(v));
+                    addr = addr.add(1);
                 }
             }
 
-            self.bitmap
-                .mark_dirty(0, addr as usize - self.addr as usize)
+            self.bitmap.mark_dirty(0, addr as usize - start as usize);
         }
     }
 }
@@ -1277,7 +1362,9 @@ impl<'a, B: BitmapSlice> From<VolatileSlice<'a, B>> for VolatileArrayRef<'a, u8,
     fn from(slice: VolatileSlice<'a, B>) -> Self {
         // SAFETY: Safe because the result has the same lifetime and points to the same
         // memory as the incoming VolatileSlice.
-        unsafe { VolatileArrayRef::with_bitmap(slice.as_ptr(), slice.len(), slice.bitmap) }
+        unsafe {
+            VolatileArrayRef::with_bitmap(slice.as_ptr(), slice.len(), slice.bitmap, slice.mmap)
+        }
     }
 }
 
@@ -1391,8 +1478,17 @@ mod copy_slice_impl {
         slice: &VolatileSlice<'_, B>,
         total: usize,
     ) -> usize {
+        #[cfg(not(all(feature = "xen", unix)))]
+        let addr = slice.as_ptr();
+
+        #[cfg(all(feature = "xen", unix))]
+        let (addr, _slice) = {
+            let slice = mmap_slice(slice.mmap, slice.as_ptr(), total, libc::PROT_READ);
+            (slice.addr(), slice)
+        };
+
         // SAFETY: guaranteed by function invariants.
-        copy_slice(dst, slice.as_ptr(), total)
+        copy_slice(dst, addr, total)
     }
 
     /// Copies `total` bytes from 'src' to `slice`
@@ -1404,10 +1500,36 @@ mod copy_slice_impl {
         src: *const u8,
         total: usize,
     ) -> usize {
+        #[cfg(not(all(feature = "xen", unix)))]
+        let addr = slice.as_ptr();
+
+        #[cfg(all(feature = "xen", unix))]
+        let (addr, _slice) = {
+            let slice = mmap_slice(slice.mmap, slice.as_ptr(), total, libc::PROT_WRITE);
+            (slice.addr(), slice)
+        };
+
         // SAFETY: guaranteed by function invariants.
-        let count = copy_slice(slice.as_ptr(), src, total);
+        let count = copy_slice(addr, src, total);
         slice.bitmap.mark_dirty(0, count);
         count
+    }
+
+    #[cfg(all(feature = "xen", unix))]
+    /// Maps memory in Xen specific way on the fly
+    ///
+    /// The returned `MmapSlice` object must be dropped only after the read/write operation
+    /// on the returned mapped address are over.
+    pub(super) fn mmap_slice(
+        mmap: Option<&MmapInfo>,
+        addr: *mut u8,
+        len: usize,
+        prot: i32,
+    ) -> crate::MmapSlice {
+        match mmap {
+            Some(mmap) => mmap.mmap_slice(addr, prot, len).unwrap(),
+            None => crate::MmapSlice::new(addr),
+        }
     }
 }
 
@@ -2095,7 +2217,7 @@ mod tests {
         // Invoke the `Bytes` test helper function.
         {
             let bitmap = AtomicBitmap::new(len, page_size);
-            let slice = unsafe { VolatileSlice::with_bitmap(buf, len, bitmap.slice_at(0)) };
+            let slice = unsafe { VolatileSlice::with_bitmap(buf, len, bitmap.slice_at(0), None) };
 
             test_bytes(
                 &slice,
@@ -2111,18 +2233,18 @@ mod tests {
         // Invoke the `VolatileMemory` test helper function.
         {
             let bitmap = AtomicBitmap::new(len, page_size);
-            let slice = unsafe { VolatileSlice::with_bitmap(buf, len, bitmap.slice_at(0)) };
+            let slice = unsafe { VolatileSlice::with_bitmap(buf, len, bitmap.slice_at(0), None) };
             test_volatile_memory(&slice);
         }
 
         let bitmap = AtomicBitmap::new(len, page_size);
-        let slice = unsafe { VolatileSlice::with_bitmap(buf, len, bitmap.slice_at(0)) };
+        let slice = unsafe { VolatileSlice::with_bitmap(buf, len, bitmap.slice_at(0), None) };
 
         let bitmap2 = AtomicBitmap::new(len, page_size);
-        let slice2 = unsafe { VolatileSlice::with_bitmap(buf, len, bitmap2.slice_at(0)) };
+        let slice2 = unsafe { VolatileSlice::with_bitmap(buf, len, bitmap2.slice_at(0), None) };
 
         let bitmap3 = AtomicBitmap::new(len, page_size);
-        let slice3 = unsafe { VolatileSlice::with_bitmap(buf, len, bitmap3.slice_at(0)) };
+        let slice3 = unsafe { VolatileSlice::with_bitmap(buf, len, bitmap3.slice_at(0), None) };
 
         assert!(range_is_clean(slice.bitmap(), 0, slice.len()));
         assert!(range_is_clean(slice2.bitmap(), 0, slice2.len()));
@@ -2180,8 +2302,9 @@ mod tests {
         let page_size = 0x1000;
 
         let bitmap = AtomicBitmap::new(size_of_val(&val), page_size);
-        let vref =
-            unsafe { VolatileRef::with_bitmap(buf.as_mut_ptr() as *mut u8, bitmap.slice_at(0)) };
+        let vref = unsafe {
+            VolatileRef::with_bitmap(buf.as_mut_ptr() as *mut u8, bitmap.slice_at(0), None)
+        };
 
         assert!(range_is_clean(vref.bitmap(), 0, vref.len()));
         vref.store(val);
@@ -2198,6 +2321,7 @@ mod tests {
                 buf.as_mut_ptr() as *mut u8,
                 index + 1,
                 bitmap.slice_at(0),
+                None,
             )
         };
 
@@ -2228,6 +2352,7 @@ mod tests {
                     buf.as_mut_ptr() as *mut u8,
                     index + 1,
                     bitmap.slice_at(0),
+                    None,
                 )
             };
 
@@ -2244,6 +2369,7 @@ mod tests {
                     buf.as_mut_ptr() as *mut u8,
                     index + 1,
                     bitmap.slice_at(0),
+                    None,
                 )
             };
 


### PR DESCRIPTION
Xen allows two memory mapping mechanisms:
- Foreign mapping: entire guest space is mapped at once.
- Grant mapping: guest controls what backend is allowed to map.

Both these mechanisms required additional mapping support, for example
an ioctl() needs to be issued (with arguments passed from backend),
along with mmap().

Also for grant memory mapping, the mapping can't be done in advance and
is done on the fly and so the changes to VolatileSlice.

Add memory mapping support for both these cases, under a new feature
"xen".

Signed-off-by: Viresh Kumar <viresh.kumar@linaro.org>
