### PR TITLE
Implement ByteValued for i128/u128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased 
+
+### Added 
+
+- [[#237]](https://github.com/rust-vmm/vm-memory/pull/237) Implement `ByteValued` for `i/u128`.
+
 ## [v0.11.0]
 
 ### Added

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -155,11 +155,13 @@ byte_valued_type!(u8);
 byte_valued_type!(u16);
 byte_valued_type!(u32);
 byte_valued_type!(u64);
+byte_valued_type!(u128);
 byte_valued_type!(usize);
 byte_valued_type!(i8);
 byte_valued_type!(i16);
 byte_valued_type!(i32);
 byte_valued_type!(i64);
+byte_valued_type!(i128);
 byte_valued_type!(isize);
 
 /// A trait used to identify types which can be accessed atomically by proxy.
@@ -362,7 +364,7 @@ pub(crate) mod tests {
     where
         T: ByteValued + PartialEq + Debug + Default,
     {
-        let mut data = [0u8; 32];
+        let mut data = [0u8; 48];
         let pre_len = {
             let (pre, _, _) = unsafe { data.align_to::<T>() };
             pre.len()
@@ -377,7 +379,7 @@ pub(crate) mod tests {
                 assert_eq!(val.as_mut_slice(), aligned_data);
             }
         }
-        for i in 1..size_of::<T>() {
+        for i in 1..size_of::<T>().min(align_of::<T>()) {
             let begin = pre_len + i;
             let end = begin + size_of::<T>();
             let unaligned_data = &mut data[begin..end];
@@ -401,11 +403,13 @@ pub(crate) mod tests {
         check_byte_valued_type::<u16>();
         check_byte_valued_type::<u32>();
         check_byte_valued_type::<u64>();
+        check_byte_valued_type::<u128>();
         check_byte_valued_type::<usize>();
         check_byte_valued_type::<i8>();
         check_byte_valued_type::<i16>();
         check_byte_valued_type::<i32>();
         check_byte_valued_type::<i64>();
+        check_byte_valued_type::<i128>();
         check_byte_valued_type::<isize>();
     }
 


### PR DESCRIPTION
### Summary of the PR

Implements `ByteValued` for u128/i128, as well as arrays of them.

I also looked at turning the array implementations into one using const generics (to remove the restriction on them being only implemented for array sizes up to 32), but a combination of `Default` being a super trait of `ByteValued` and https://github.com/rust-lang/rust/issues/61415 make this impossible

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
