### PR TITLE
mmap_xen: Don't drop the FileOffset while in use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,19 @@
 # Changelog
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Deprecated
+
+## [v0.12.1]
+
+### Fixed
+- [[#241]](https://github.com/rust-vmm/vm-memory/pull/245) mmap_xen: Don't drop
+  the FileOffset while in use #245
 
 ## [v0.12.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vm-memory"
-version = "0.12.0"
+version = "0.12.1"
 description = "Safe abstractions for accessing the VM physical memory"
 keywords = ["memory"]
 categories = ["memory-management"]


### PR DESCRIPTION
The drop implementation of `struct MmapXenGrant` issues an Ioctl call, which uses the file descriptor.

Currently the FileOffset is getting dropped before that, and results in "Bad File Descriptor" error from the Ioctl. This commit fixes it by keeping a copy of the same in `struct MmapXenGrant`.