### PR TITLE
[RFC] `ReadVolatile` and `WriteVolatile` traits for efficient data transfer from/to guest memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- [[#247]](https://github.com/rust-vmm/vm-memory/pull/247) Add `ReadVolatile` and
+  `WriteVolatile` traits which are equivalents of `Read`/`Write` with volatile
+  access semantics.
+
+### Changed
+
+- [[#247]](https://github.com/rust-vmm/vm-memory/pull/247) Deprecate
+  `Bytes::{read_from, read_exact_from, write_to, write_all_to}`. Instead use
+  `ReadVolatile`/`WriteVolatile`, which do not incur the performance penalty
+  of copying to hypervisor memory due to `Read`/`Write` being incompatible
+  with volatile semantics (see also #217).
+
+
 ## [v0.12.2]
 
 ### Fixed

--- a/benches/mmap/mod.rs
+++ b/benches/mmap/mod.rs
@@ -8,7 +8,6 @@ extern crate criterion;
 extern crate vm_memory;
 
 use std::fs::{File, OpenOptions};
-use std::io::Cursor;
 use std::mem::size_of;
 use std::path::Path;
 
@@ -105,7 +104,7 @@ pub fn benchmark_for_mmap(c: &mut Criterion) {
         c.bench_function(format!("read_from_{:#0X}", offset).as_str(), |b| {
             b.iter(|| {
                 black_box(&memory)
-                    .read_from(address, &mut Cursor::new(&image), ACCESS_SIZE)
+                    .read_volatile_from(address, &mut image.as_slice(), ACCESS_SIZE)
                     .unwrap()
             })
         });
@@ -113,7 +112,7 @@ pub fn benchmark_for_mmap(c: &mut Criterion) {
         c.bench_function(format!("read_from_file_{:#0X}", offset).as_str(), |b| {
             b.iter(|| {
                 black_box(&memory)
-                    .read_from(address, &mut file, ACCESS_SIZE)
+                    .read_volatile_from(address, &mut file, ACCESS_SIZE)
                     .unwrap()
             })
         });
@@ -121,7 +120,7 @@ pub fn benchmark_for_mmap(c: &mut Criterion) {
         c.bench_function(format!("read_exact_from_{:#0X}", offset).as_str(), |b| {
             b.iter(|| {
                 black_box(&memory)
-                    .read_exact_from(address, &mut Cursor::new(&mut image), ACCESS_SIZE)
+                    .read_exact_volatile_from(address, &mut image.as_slice(), ACCESS_SIZE)
                     .unwrap()
             })
         });
@@ -154,7 +153,7 @@ pub fn benchmark_for_mmap(c: &mut Criterion) {
         c.bench_function(format!("write_to_{:#0X}", offset).as_str(), |b| {
             b.iter(|| {
                 black_box(&memory)
-                    .write_to(address, &mut Cursor::new(&mut image), ACCESS_SIZE)
+                    .write_volatile_to(address, &mut image.as_mut_slice(), ACCESS_SIZE)
                     .unwrap()
             })
         });
@@ -162,7 +161,7 @@ pub fn benchmark_for_mmap(c: &mut Criterion) {
         c.bench_function(format!("write_to_file_{:#0X}", offset).as_str(), |b| {
             b.iter(|| {
                 black_box(&memory)
-                    .write_to(address, &mut file_to_write, ACCESS_SIZE)
+                    .write_volatile_to(address, &mut file_to_write, ACCESS_SIZE)
                     .unwrap()
             })
         });
@@ -170,7 +169,7 @@ pub fn benchmark_for_mmap(c: &mut Criterion) {
         c.bench_function(format!("write_exact_to_{:#0X}", offset).as_str(), |b| {
             b.iter(|| {
                 black_box(&memory)
-                    .write_all_to(address, &mut Cursor::new(&mut image), ACCESS_SIZE)
+                    .write_all_volatile_to(address, &mut image.as_mut_slice(), ACCESS_SIZE)
                     .unwrap()
             })
         });

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 92.2,
+  "coverage_score": 91.2,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap,backend-atomic,backend-bitmap"
 }

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -267,6 +267,7 @@ pub(crate) mod tests {
         dirty_offset += step;
 
         // Test `read_from`.
+        #[allow(deprecated)] // test of deprecated functions
         h.test_access(bytes, dirty_offset, BUF_SIZE, |m, addr| {
             assert_eq!(
                 m.read_from(addr, &mut Cursor::new(&buf), BUF_SIZE).unwrap(),
@@ -277,6 +278,7 @@ pub(crate) mod tests {
         dirty_offset += step;
 
         // Test `read_exact_from`.
+        #[allow(deprecated)] // test of deprecated functions
         h.test_access(bytes, dirty_offset, BUF_SIZE, |m, addr| {
             m.read_exact_from(addr, &mut Cursor::new(&buf), BUF_SIZE)
                 .unwrap()

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -280,6 +280,9 @@ pub trait Bytes<A> {
     /// * `addr` - Begin writing at this address.
     /// * `src` - Copy from `src` into the container.
     /// * `count` - Copy `count` bytes from `src` into the container.
+    #[deprecated(
+        note = "Use `.read_from_volatile` or the functions of the `ReadVolatile` trait instead"
+    )]
     fn read_from<F>(&self, addr: A, src: &mut F, count: usize) -> Result<usize, Self::E>
     where
         F: Read;
@@ -295,6 +298,9 @@ pub trait Bytes<A> {
     /// * `addr` - Begin writing at this address.
     /// * `src` - Copy from `src` into the container.
     /// * `count` - Copy exactly `count` bytes from `src` into the container.
+    #[deprecated(
+        note = "Use `.read_exact_from_volatile` or the functions of the `ReadVolatile` trait instead"
+    )]
     fn read_exact_from<F>(&self, addr: A, src: &mut F, count: usize) -> Result<(), Self::E>
     where
         F: Read;
@@ -307,6 +313,9 @@ pub trait Bytes<A> {
     /// * `addr` - Begin reading from this address.
     /// * `dst` - Copy from the container to `dst`.
     /// * `count` - Copy `count` bytes from the container to `dst`.
+    #[deprecated(
+        note = "Use `.write_to_volatile` or the functions of the `WriteVolatile` trait instead"
+    )]
     fn write_to<F>(&self, addr: A, dst: &mut F, count: usize) -> Result<usize, Self::E>
     where
         F: Write;
@@ -322,6 +331,9 @@ pub trait Bytes<A> {
     /// * `addr` - Begin reading from this address.
     /// * `dst` - Copy from the container to `dst`.
     /// * `count` - Copy exactly `count` bytes from the container to `dst`.
+    #[deprecated(
+        note = "Use `.write_all_to_volatile` or the functions of the `WriteVolatile` trait instead"
+    )]
     fn write_all_to<F>(&self, addr: A, dst: &mut F, count: usize) -> Result<(), Self::E>
     where
         F: Write;

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -281,7 +281,7 @@ pub trait Bytes<A> {
     /// * `src` - Copy from `src` into the container.
     /// * `count` - Copy `count` bytes from `src` into the container.
     #[deprecated(
-        note = "Use `.read_from_volatile` or the functions of the `ReadVolatile` trait instead"
+        note = "Use `.read_volatile_from` or the functions of the `ReadVolatile` trait instead"
     )]
     fn read_from<F>(&self, addr: A, src: &mut F, count: usize) -> Result<usize, Self::E>
     where
@@ -299,7 +299,7 @@ pub trait Bytes<A> {
     /// * `src` - Copy from `src` into the container.
     /// * `count` - Copy exactly `count` bytes from `src` into the container.
     #[deprecated(
-        note = "Use `.read_exact_from_volatile` or the functions of the `ReadVolatile` trait instead"
+        note = "Use `.read_exact_volatile_from` or the functions of the `ReadVolatile` trait instead"
     )]
     fn read_exact_from<F>(&self, addr: A, src: &mut F, count: usize) -> Result<(), Self::E>
     where
@@ -314,7 +314,7 @@ pub trait Bytes<A> {
     /// * `dst` - Copy from the container to `dst`.
     /// * `count` - Copy `count` bytes from the container to `dst`.
     #[deprecated(
-        note = "Use `.write_to_volatile` or the functions of the `WriteVolatile` trait instead"
+        note = "Use `.write_volatile_to` or the functions of the `WriteVolatile` trait instead"
     )]
     fn write_to<F>(&self, addr: A, dst: &mut F, count: usize) -> Result<usize, Self::E>
     where
@@ -332,7 +332,7 @@ pub trait Bytes<A> {
     /// * `dst` - Copy from the container to `dst`.
     /// * `count` - Copy exactly `count` bytes from the container to `dst`.
     #[deprecated(
-        note = "Use `.write_all_to_volatile` or the functions of the `WriteVolatile` trait instead"
+        note = "Use `.write_all_volatile_to` or the functions of the `WriteVolatile` trait instead"
     )]
     fn write_all_to<F>(&self, addr: A, dst: &mut F, count: usize) -> Result<(), Self::E>
     where

--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -856,6 +856,7 @@ impl<T: GuestMemory + ?Sized> Bytes<GuestAddress> for T {
     where
         F: Read,
     {
+        #[allow(deprecated)] // this function itself is deprecated
         let res = self.read_from(addr, src, count)?;
         if res != count {
             return Err(Error::PartialBuffer {
@@ -949,6 +950,7 @@ impl<T: GuestMemory + ?Sized> Bytes<GuestAddress> for T {
     where
         F: Write,
     {
+        #[allow(deprecated)] // this function itself is deprecated
         let res = self.write_to(addr, dst, count)?;
         if res != count {
             return Err(Error::PartialBuffer {

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,0 +1,272 @@
+// Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//! Module containing versions of the standard library's [`Read`] and [`Write`] traits compatible
+//! with volatile memory accesses.
+
+use crate::bitmap::BitmapSlice;
+use crate::volatile_memory::copy_slice_impl::{copy_from_volatile_slice, copy_to_volatile_slice};
+use crate::{VolatileMemoryError, VolatileSlice};
+use std::io::ErrorKind;
+use std::os::fd::AsRawFd;
+
+/// A version of the standard library's [`Read`] trait that operates on volatile memory instead of
+/// slices
+///
+/// This trait is needed as rust slices (`&[u8]` and `&mut [u8]`) cannot be used when operating on
+/// guest memory [1].
+///
+/// [1]: https://github.com/rust-vmm/vm-memory/pull/217
+pub trait ReadVolatile {
+    /// Tries to read some bytes into the given [`VolatileSlice`] buffer, returning how many bytes
+    /// were read.
+    ///
+    /// The behavior of implementations should be identical to [`Read::read`]
+    fn read_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &mut VolatileSlice<B>,
+    ) -> Result<usize, VolatileMemoryError>;
+
+    /// Tries to fill the given [`VolatileSlice`] buffer by reading from `self` returning an error
+    /// if insufficient bytes could be read.
+    ///
+    /// The default implementation is identical to that of [`Read::read_exact`]
+    fn read_exact_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &mut VolatileSlice<B>,
+    ) -> Result<(), VolatileMemoryError> {
+        // Implementation based on https://github.com/rust-lang/rust/blob/7e7483d26e3cec7a44ef00cf7ae6c9c8c918bec6/library/std/src/io/mod.rs#L465
+
+        let mut partial_buf = buf.offset(0)?;
+
+        while !partial_buf.is_empty() {
+            match self.read_volatile(&mut partial_buf) {
+                Err(VolatileMemoryError::IOError(err)) if err.kind() == ErrorKind::Interrupted => {
+                    continue
+                }
+                Ok(0) => {
+                    return Err(VolatileMemoryError::IOError(std::io::Error::new(
+                        ErrorKind::UnexpectedEof,
+                        "failed to fill whole buffer",
+                    )))
+                }
+                Ok(bytes_read) => partial_buf = partial_buf.offset(bytes_read)?,
+                Err(err) => return Err(err),
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// A version of the standard library's [`Write`] trait that operates on volatile memory instead of
+/// slices
+///
+/// This trait is needed as rust slices (`&[u8]` and `&mut [u8]`) cannot be used when operating on
+/// guest memory [1].
+///
+/// [1]: https://github.com/rust-vmm/vm-memory/pull/217
+pub trait WriteVolatile {
+    /// Tries to write some bytes from the given [`VolatileSlice`] buffer, returning how many bytes
+    /// were written.
+    ///
+    /// The behavior of implementations should be identical to [`Write::write`]
+    fn write_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &VolatileSlice<B>,
+    ) -> Result<usize, VolatileMemoryError>;
+
+    /// Tries write the entire content of the given [`VolatileSlice`] buffer to `self` returning an
+    /// error if not all bytes could be written.
+    ///
+    /// The default implementation is identical to that of [`Write::write_all`]
+    fn write_all_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &VolatileSlice<B>,
+    ) -> Result<(), VolatileMemoryError> {
+        // Based on https://github.com/rust-lang/rust/blob/7e7483d26e3cec7a44ef00cf7ae6c9c8c918bec6/library/std/src/io/mod.rs#L1570
+
+        let mut partial_buf = buf.offset(0)?;
+
+        while !partial_buf.is_empty() {
+            match self.write_volatile(&partial_buf) {
+                Err(VolatileMemoryError::IOError(err)) if err.kind() == ErrorKind::Interrupted => {
+                    continue
+                }
+                Ok(0) => {
+                    return Err(VolatileMemoryError::IOError(std::io::Error::new(
+                        ErrorKind::WriteZero,
+                        "failed to write whole buffer",
+                    )))
+                }
+                Ok(bytes_written) => partial_buf = partial_buf.offset(bytes_written)?,
+                Err(err) => return Err(err),
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// We explicitly implement our traits for [`std::fs::File`] and [`std::os::unix::net::UnixStream`]
+// instead of providing blanket implementation for [`AsRawFd`] due to trait coherence limitations: A
+// blanket implementation would prevent us from providing implementations for `&mut [u8]` below, as
+// "an upstream crate could implement AsRawFd for &mut [u8]`.
+
+macro_rules! impl_read_write_volatile_for_raw_fd {
+    ($raw_fd_ty:ty) => {
+        impl ReadVolatile for $raw_fd_ty {
+            fn read_volatile<B: BitmapSlice>(
+                &mut self,
+                buf: &mut VolatileSlice<B>,
+            ) -> Result<usize, VolatileMemoryError> {
+                read_volatile_raw_fd(self, buf)
+            }
+        }
+
+        impl WriteVolatile for $raw_fd_ty {
+            fn write_volatile<B: BitmapSlice>(
+                &mut self,
+                buf: &VolatileSlice<B>,
+            ) -> Result<usize, VolatileMemoryError> {
+                write_volatile_raw_fd(self, buf)
+            }
+        }
+    };
+}
+
+impl_read_write_volatile_for_raw_fd!(std::fs::File);
+impl_read_write_volatile_for_raw_fd!(std::os::unix::net::UnixStream);
+impl_read_write_volatile_for_raw_fd!(std::os::fd::OwnedFd);
+impl_read_write_volatile_for_raw_fd!(std::os::fd::BorrowedFd<'_>);
+
+/// Tries to do a single `read` syscall on the provided file descriptor, storing the data raed in
+/// the given [`VolatileSlice`].
+///
+/// Returns the numbers of bytes read.
+fn read_volatile_raw_fd<Fd: AsRawFd>(
+    raw_fd: &mut Fd,
+    buf: &mut VolatileSlice<impl BitmapSlice>,
+) -> Result<usize, VolatileMemoryError> {
+    let fd = raw_fd.as_raw_fd();
+    let guard = buf.ptr_guard_mut();
+
+    let dst = guard.as_ptr().cast::<libc::c_void>();
+
+    // SAFETY: We got a valid file descriptor from `AsRawFd`. The memory pointed to by `dst` is
+    // valid for writes of length `buf.len() by the invariants upheld by the constructor
+    // of `VolatileSlice`.
+    let bytes_read = unsafe { libc::read(fd, dst, buf.len()) };
+
+    if bytes_read < 0 {
+        // We don't know if a partial read might have happened, so mark everything as dirty
+        buf.bitmap().mark_dirty(0, buf.len());
+
+        Err(VolatileMemoryError::IOError(std::io::Error::last_os_error()))
+    } else {
+        let bytes_read = bytes_read.try_into().unwrap();
+        buf.bitmap().mark_dirty(0, bytes_read);
+        Ok(bytes_read)
+    }
+}
+
+/// Tries to do a single `write` syscall on the provided file descriptor, attempting to write the
+/// data stored in the given [`VolatileSlice`].
+///
+/// Returns the numbers of bytes written.
+fn write_volatile_raw_fd<Fd: AsRawFd>(
+    raw_fd: &mut Fd,
+    buf: &VolatileSlice<impl BitmapSlice>,
+) -> Result<usize, VolatileMemoryError> {
+    let fd = raw_fd.as_raw_fd();
+    let guard = buf.ptr_guard();
+
+    let src = guard.as_ptr().cast::<libc::c_void>();
+
+    // SAFETY: We got a valid file descriptor from `AsRawFd`. The memory pointed to by `src` is
+    // valid for reads of length `buf.len() by the invariants upheld by the constructor
+    // of `VolatileSlice`.
+    let bytes_written = unsafe { libc::write(fd, src, buf.len()) };
+
+    if bytes_written < 0 {
+        Err(VolatileMemoryError::IOError(std::io::Error::last_os_error()))
+    } else {
+        Ok(bytes_written.try_into().unwrap())
+    }
+}
+
+impl WriteVolatile for &mut [u8] {
+    fn write_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &VolatileSlice<B>,
+    ) -> Result<usize, VolatileMemoryError> {
+        let total = buf.len().min(self.len());
+        let src = buf.subslice(0, total)?;
+
+        // SAFETY:
+        // We check above that `src` is contiguously allocated memory of length `total <= self.len())`.
+        // Furthermore, both src and dst of the call to
+        // copy_from_volatile_slice are valid for reads and writes respectively of length `total`
+        // since total is the minimum of lengths of the memory areas pointed to. The areas do not
+        // overlap, since `dst` is inside guest memory, and buf is a slice (no slices to guest
+        // memory are possible without violating rust's aliasing rules).
+        let written = unsafe { copy_from_volatile_slice(self.as_mut_ptr(), &src, total) };
+
+        // Advance the slice, just like the stdlib: https://doc.rust-lang.org/src/std/io/impls.rs.html#335
+        *self = std::mem::take(self).split_at_mut(written).1;
+
+        Ok(written)
+    }
+
+    fn write_all_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &VolatileSlice<B>,
+    ) -> Result<(), VolatileMemoryError> {
+        // Based on https://github.com/rust-lang/rust/blob/f7b831ac8a897273f78b9f47165cf8e54066ce4b/library/std/src/io/impls.rs#L376-L382
+        if self.write_volatile(buf)? == buf.len() {
+            Ok(())
+        } else {
+            Err(VolatileMemoryError::IOError(std::io::Error::new(
+                ErrorKind::WriteZero,
+                "failed to write whole buffer",
+            )))
+        }
+    }
+}
+
+impl ReadVolatile for &[u8] {
+    fn read_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &mut VolatileSlice<B>,
+    ) -> Result<usize, VolatileMemoryError> {
+        let total = buf.len().min(self.len());
+        let dst = buf.subslice(0, total)?;
+
+        // SAFETY:
+        // We check above that `dst` is contiguously allocated memory of length `total <= self.len())`.
+        // Furthermore, both src and dst of the call to copy_to_volatile_slice are valid for reads
+        // and writes respectively of length `total` since total is the minimum of lengths of the
+        // memory areas pointed to. The areas do not overlap, since `dst` is inside guest memory,
+        // and buf is a slice (no slices to guest memory are possible without violating rust's aliasing rules).
+        let read = unsafe { copy_to_volatile_slice(&dst, self.as_ptr(), total) };
+
+        // Advance the slice, just like the stdlib: https://doc.rust-lang.org/src/std/io/impls.rs.html#232-310
+        *self = self.split_at(read).1;
+
+        Ok(read)
+    }
+
+    fn read_exact_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &mut VolatileSlice<B>,
+    ) -> Result<(), VolatileMemoryError> {
+        // Based on https://github.com/rust-lang/rust/blob/f7b831ac8a897273f78b9f47165cf8e54066ce4b/library/std/src/io/impls.rs#L282-L302
+        if buf.len() > self.len() {
+            return Err(VolatileMemoryError::IOError(std::io::Error::new(
+                ErrorKind::UnexpectedEof,
+                "failed to fill whole buffer",
+            )));
+        }
+
+        self.read_volatile(buf).map(|_| ())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,9 @@ pub use guest_memory::{
     GuestMemoryRegion, GuestUsize, MemoryRegionAddress, Result as GuestMemoryResult,
 };
 
+pub mod io;
+pub use io::{ReadVolatile, WriteVolatile};
+
 #[cfg(all(feature = "backend-mmap", not(feature = "xen"), unix))]
 mod mmap_unix;
 

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -273,6 +273,7 @@ impl<B: Bitmap> Bytes<MemoryRegionAddress> for GuestRegionMmap<B> {
         F: Read,
     {
         let maddr = addr.raw_value() as usize;
+        #[allow(deprecated)] // function itself is deprecated
         self.as_volatile_slice()
             .unwrap()
             .read_from::<F>(maddr, src, count)
@@ -318,6 +319,7 @@ impl<B: Bitmap> Bytes<MemoryRegionAddress> for GuestRegionMmap<B> {
         F: Read,
     {
         let maddr = addr.raw_value() as usize;
+        #[allow(deprecated)] // function itself is deprecated
         self.as_volatile_slice()
             .unwrap()
             .read_exact_from::<F>(maddr, src, count)
@@ -363,6 +365,7 @@ impl<B: Bitmap> Bytes<MemoryRegionAddress> for GuestRegionMmap<B> {
         F: Write,
     {
         let maddr = addr.raw_value() as usize;
+        #[allow(deprecated)] // function itself is deprecated
         self.as_volatile_slice()
             .unwrap()
             .write_to::<F>(maddr, dst, count)
@@ -408,6 +411,7 @@ impl<B: Bitmap> Bytes<MemoryRegionAddress> for GuestRegionMmap<B> {
         F: Write,
     {
         let maddr = addr.raw_value() as usize;
+        #[allow(deprecated)] // function itself is deprecated
         self.as_volatile_slice()
             .unwrap()
             .write_all_to::<F>(maddr, dst, count)
@@ -1177,7 +1181,7 @@ mod tests {
                 File::open(Path::new("c:\\Windows\\system32\\ntoskrnl.exe")).unwrap()
             };
             gm.write_obj(!0u32, addr).unwrap();
-            gm.read_exact_from(addr, &mut file, mem::size_of::<u32>())
+            gm.read_exact_volatile_from(addr, &mut file, mem::size_of::<u32>())
                 .unwrap();
             let value: u32 = gm.read_obj(addr).unwrap();
             if cfg!(unix) {
@@ -1186,8 +1190,8 @@ mod tests {
                 assert_eq!(value, 0x0090_5a4d);
             }
 
-            let mut sink = Vec::new();
-            gm.write_all_to(addr, &mut sink, mem::size_of::<u32>())
+            let mut sink = vec![0; mem::size_of::<u32>()];
+            gm.write_all_volatile_to(addr, &mut sink.as_mut_slice(), mem::size_of::<u32>())
                 .unwrap();
             if cfg!(unix) {
                 assert_eq!(sink, vec![0; mem::size_of::<u32>()]);


### PR DESCRIPTION
### Summary of the PR

With https://github.com/rust-vmm/vm-memory/pull/217, various `read_from` and `write_to` methods across vm-memory
incurred a performance penalty due to an additional copy of all data
read and written. This is due to these functions operating on arbitrary
Read/Write implementations, which cannot generally be assumed to respect
the volatile semantics of guest memory. Additionally, they required
taking slices to guest memory, which was undefined behavior.

This patch series fixes those short-comings by introducing a pair of new
traits, `ReadVolatile` and `WriteVolatile` which are identical to the
standard library's `Read` and `Write` traits, with the difference being
that they operate on `VolatileSlice`s instead of `&mut [u8]`. Using
these traits will therefore not incur the performance penalty of https://github.com/rust-vmm/vm-memory/pull/217.
Additionally, this will make using the vm-memory library easier for
users familiar with std::io, as the APIs will be more familiar (in
particular, the unintuitive "swapping" of reader/writer src and dst of
the old `read_from`/`write_to` APIs is resolved).

Please consider this as a not-completely-polished proposal for which I am seeking feedback. The code is based on what we wrote in firecracker to mitigate the performance impact of upgrading to 0.10.0 as a result of #217.

### Open Questions
- this patch series does not attempt to implement vectored I/O via `readv`/`writev`. I think there is definitely a usecase for this, since both firecracker and virtio-fsd use vectored I/O in various places. It would be nice to upstream something similar to https://gitlab.com/virtio-fs/virtiofsd/-/blob/main/src/file_traits.rs to `ReadVolatile`/`WriteVolatile`. Maybe someone from that team could chime in?
- I'd honestly love to cut down the entire jungle of `read` and `write` functions in this crate, but considered that change to be somewhat out of scope here (with this PR only aiming to address the inability to transfer data efficiently between a file descriptor and guest memory). I feel however that deprecating all `read`/`write` functions would greatly simplify this library at the cost of users having to call `get_slice()`. Maybe via turning the `Bytes` trait into something that represents "`self` can be turned into a `VolatileSlice`", as `read` -> `read_volatile`, `read_slice` -> `read_exact_volatile`, `write` -> `write_volatile` and `write_slice` -> `write_all_volatile`. 

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
