### PR TITLE
fix: Validate return value of get_slice in VolatileMemory functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,22 @@
 # Changelog
-## [Unreleased]
 
-### Added
-
-### Changed
+## [v0.12.2]
 
 ### Fixed
+- [[#251]](https://github.com/rust-vmm/vm-memory/pull/251): Inserted checks
+  that verify that the value returned by `VolatileMemory::get_slice` is of
+  the correct length.
 
 ### Deprecated
+- [[#244]](https://github.com/rust-vmm/vm-memory/pull/241) Deprecate volatile
+  memory's `as_ptr()` interfaces. The new interfaces to be used instead are:
+  `ptr_guard()` and `ptr_guard_mut()`.
 
 ## [v0.12.1]
 
 ### Fixed
 - [[#241]](https://github.com/rust-vmm/vm-memory/pull/245) mmap_xen: Don't drop
   the FileOffset while in use #245
-
-## [Unreleased]
-
-### Deprecated
-
-- [[#244]](https://github.com/rust-vmm/vm-memory/pull/241) Deprecate volatile
-  memory's `as_ptr()` interfaces. The new interfaces to be used instead are:
-  `ptr_guard()` and `ptr_guard_mut()`.
 
 ## [v0.12.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vm-memory"
-version = "0.12.1"
+version = "0.12.2"
 description = "Safe abstractions for accessing the VM physical memory"
 keywords = ["memory"]
 categories = ["memory-management"]


### PR DESCRIPTION
### Summary of the PR

An issue was discovered in the default implementations of the VolatileMemory::{get_atomic_ref, aligned_as_ref, aligned_as_mut, get_ref, get_array_ref} trait functions, which allows out-of-bounds memory access if the VolatileMemory::get_slice function returns a VolatileSlice whose length is less than the function’s count argument. No implementations of get_slice provided in vm_memory are affected. Users of custom VolatileMemory implementations may be impacted if the custom implementation does not adhere to get_slice's documentation.

This commit fixes this issue by inserting a check that verifies that the VolatileSlice returned by get_slice is of the correct length.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
