### PR TITLE
mmap_xen: Update to bitflags 2.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ xen = ["backend-mmap", "bitflags", "vmm-sys-util"]
 [dependencies]
 libc = "0.2.39"
 arc-swap = { version = "1.0.0", optional = true }
-bitflags = { version = "1.0", optional = true }
+bitflags = { version = "2.4.0", optional = true }
 thiserror = "1.0.40"
 vmm-sys-util = { version = "0.11.0", optional = true }
 

--- a/src/mmap_xen.rs
+++ b/src/mmap_xen.rs
@@ -432,6 +432,7 @@ impl Drop for MmapUnix {
 // Bit mask for the vhost-user xen mmap message.
 bitflags! {
     /// Flags for the Xen mmap message.
+    #[derive(Copy, Clone, Debug)]
     pub struct MmapXenFlags: u32 {
         /// Standard Unix memory mapping.
         const UNIX = 0x0;


### PR DESCRIPTION
Clippy gives this warning currently:

error: &-masking with zero
   --> src/mmap_xen.rs:433:1
    |
433 | / bitflags! {
434 | |     /// Flags for the Xen mmap message.
435 | |     pub struct MmapXenFlags: u32 {
436 | |         /// Standard Unix memory mapping.
...   |
446 | |     }
447 | | }
    | |_^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#bad_bit_mask
    = note: `#[deny(clippy::bad_bit_mask)]` on by default
    = note: this error originates in the macro `__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)

Fix it.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
