### PR TITLE
More `ReadVolatile` and `WriteVolatile` impls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - [[#256](https://github.com/rust-vmm/vm-memory/pull/256)] Implement `WriteVolatile`
   for `std::io::Stdout`.
 - [[#256](https://github.com/rust-vmm/vm-memory/pull/256)] Implement `WriteVolatile`
+  for `std::vec::Vec`.
+- [[#256](https://github.com/rust-vmm/vm-memory/pull/256)] Implement `WriteVolatile`
   for `Cursor<&mut [u8]>`.
 - [[#256](https://github.com/rust-vmm/vm-memory/pull/256)] Implement `ReadVolatile`
   for `Cursor<T: AsRef[u8]>`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Added
+
+- [[#256](https://github.com/rust-vmm/vm-memory/pull/256)] Implement `WriteVolatile`
+  for `std::io::Stdout`.
+- [[#256](https://github.com/rust-vmm/vm-memory/pull/256)] Implement `WriteVolatile`
+  for `Cursor<&mut [u8]>`.
+- [[#256](https://github.com/rust-vmm/vm-memory/pull/256)] Implement `ReadVolatile`
+  for `Cursor<T: AsRef[u8]>`.
+
 ## [v0.13.0]
 
 ### Added

--- a/src/io.rs
+++ b/src/io.rs
@@ -6,7 +6,7 @@
 use crate::bitmap::BitmapSlice;
 use crate::volatile_memory::copy_slice_impl::{copy_from_volatile_slice, copy_to_volatile_slice};
 use crate::{VolatileMemoryError, VolatileSlice};
-use std::io::ErrorKind;
+use std::io::{ErrorKind, Stdout};
 use std::os::fd::AsRawFd;
 
 /// A version of the standard library's [`Read`] trait that operates on volatile memory instead of
@@ -132,6 +132,15 @@ macro_rules! impl_read_write_volatile_for_raw_fd {
             }
         }
     };
+}
+
+impl WriteVolatile for Stdout {
+    fn write_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &VolatileSlice<B>,
+    ) -> Result<usize, VolatileMemoryError> {
+        write_volatile_raw_fd(self, buf)
+    }
 }
 
 impl_read_write_volatile_for_raw_fd!(std::fs::File);


### PR DESCRIPTION
### Summary of the PR

When upgrading other rust-vmm crates to use the new traits introduced in https://github.com/rust-vmm/vm-memory/pull/247, it was noticed that we a missing a few `ReadVolatile` and `WriteVolatile` implementations. This PR tries to supply these. 

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
