### PR TITLE
Use non-zero page size

### DIFF
--- a/src/bitmap/backend/atomic_bitmap_arc.rs
+++ b/src/bitmap/backend/atomic_bitmap_arc.rs
@@ -77,10 +77,14 @@ mod tests {
     use super::*;
 
     use crate::bitmap::tests::test_bitmap;
+    use std::num::NonZeroUsize;
 
     #[test]
     fn test_bitmap_impl() {
-        let b = AtomicBitmapArc::new(AtomicBitmap::new(0x2000, 128));
+        // SAFETY: `128` is non-zero.
+        let b = AtomicBitmapArc::new(AtomicBitmap::new(0x2000, unsafe {
+            NonZeroUsize::new_unchecked(128)
+        }));
         test_bitmap(&b);
     }
 }

--- a/src/bitmap/backend/slice.rs
+++ b/src/bitmap/backend/slice.rs
@@ -99,6 +99,7 @@ mod tests {
 
     use crate::bitmap::tests::{range_is_clean, range_is_dirty, test_bitmap};
     use crate::bitmap::AtomicBitmap;
+    use std::num::NonZeroUsize;
 
     #[test]
     fn test_slice() {
@@ -107,7 +108,7 @@ mod tests {
         let dirty_len = 0x100;
 
         {
-            let bitmap = AtomicBitmap::new(bitmap_size, 1);
+            let bitmap = AtomicBitmap::new(bitmap_size, NonZeroUsize::MIN);
             let slice1 = bitmap.slice_at(0);
             let slice2 = bitmap.slice_at(dirty_offset);
 
@@ -121,7 +122,7 @@ mod tests {
         }
 
         {
-            let bitmap = AtomicBitmap::new(bitmap_size, 1);
+            let bitmap = AtomicBitmap::new(bitmap_size, NonZeroUsize::MIN);
             let slice = bitmap.slice_at(0);
             test_bitmap(&slice);
         }

--- a/src/mmap_unix.rs
+++ b/src/mmap_unix.rs
@@ -445,6 +445,7 @@ mod tests {
     use super::*;
 
     use std::io::Write;
+    use std::num::NonZeroUsize;
     use std::slice;
     use std::sync::Arc;
     use vmm_sys_util::tempfile::TempFile;
@@ -598,7 +599,7 @@ mod tests {
         assert!(r.owned());
 
         let region_size = 0x10_0000;
-        let bitmap = AtomicBitmap::new(region_size, 0x1000);
+        let bitmap = AtomicBitmap::new(region_size, unsafe { NonZeroUsize::new_unchecked(0x1000) });
         let builder = MmapRegionBuilder::new_with_bitmap(region_size, bitmap)
             .with_hugetlbfs(true)
             .with_mmap_prot(libc::PROT_READ | libc::PROT_WRITE);

--- a/src/volatile_memory.rs
+++ b/src/volatile_memory.rs
@@ -1640,12 +1640,15 @@ mod tests {
     use std::thread::spawn;
 
     use matches::assert_matches;
+    use std::num::NonZeroUsize;
     use vmm_sys_util::tempfile::TempFile;
 
     use crate::bitmap::tests::{
         check_range, range_is_clean, range_is_dirty, test_bytes, test_volatile_memory,
     };
     use crate::bitmap::{AtomicBitmap, RefSlice};
+
+    const DEFAULT_PAGE_SIZE: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(0x1000) };
 
     #[test]
     fn test_display_error() {
@@ -2296,14 +2299,13 @@ mod tests {
         let val = 123u64;
         let dirty_offset = 0x1000;
         let dirty_len = size_of_val(&val);
-        let page_size = 0x1000;
 
         let len = 0x10000;
         let buf = unsafe { std::alloc::alloc_zeroed(Layout::from_size_align(len, 8).unwrap()) };
 
         // Invoke the `Bytes` test helper function.
         {
-            let bitmap = AtomicBitmap::new(len, page_size);
+            let bitmap = AtomicBitmap::new(len, DEFAULT_PAGE_SIZE);
             let slice = unsafe { VolatileSlice::with_bitmap(buf, len, bitmap.slice_at(0), None) };
 
             test_bytes(
@@ -2319,18 +2321,18 @@ mod tests {
 
         // Invoke the `VolatileMemory` test helper function.
         {
-            let bitmap = AtomicBitmap::new(len, page_size);
+            let bitmap = AtomicBitmap::new(len, DEFAULT_PAGE_SIZE);
             let slice = unsafe { VolatileSlice::with_bitmap(buf, len, bitmap.slice_at(0), None) };
             test_volatile_memory(&slice);
         }
 
-        let bitmap = AtomicBitmap::new(len, page_size);
+        let bitmap = AtomicBitmap::new(len, DEFAULT_PAGE_SIZE);
         let slice = unsafe { VolatileSlice::with_bitmap(buf, len, bitmap.slice_at(0), None) };
 
-        let bitmap2 = AtomicBitmap::new(len, page_size);
+        let bitmap2 = AtomicBitmap::new(len, DEFAULT_PAGE_SIZE);
         let slice2 = unsafe { VolatileSlice::with_bitmap(buf, len, bitmap2.slice_at(0), None) };
 
-        let bitmap3 = AtomicBitmap::new(len, page_size);
+        let bitmap3 = AtomicBitmap::new(len, DEFAULT_PAGE_SIZE);
         let slice3 = unsafe { VolatileSlice::with_bitmap(buf, len, bitmap3.slice_at(0), None) };
 
         assert!(range_is_clean(slice.bitmap(), 0, slice.len()));
@@ -2386,9 +2388,8 @@ mod tests {
     fn test_volatile_ref_dirty_tracking() {
         let val = 123u64;
         let mut buf = vec![val];
-        let page_size = 0x1000;
 
-        let bitmap = AtomicBitmap::new(size_of_val(&val), page_size);
+        let bitmap = AtomicBitmap::new(size_of_val(&val), DEFAULT_PAGE_SIZE);
         let vref = unsafe {
             VolatileRef::with_bitmap(buf.as_mut_ptr() as *mut u8, bitmap.slice_at(0), None)
         };
@@ -2398,8 +2399,11 @@ mod tests {
         assert!(range_is_dirty(vref.bitmap(), 0, vref.len()));
     }
 
-    fn test_volatile_array_ref_copy_from_tracking<T>(buf: &mut [T], index: usize, page_size: usize)
-    where
+    fn test_volatile_array_ref_copy_from_tracking<T>(
+        buf: &mut [T],
+        index: usize,
+        page_size: NonZeroUsize,
+    ) where
         T: ByteValued + From<u8>,
     {
         let bitmap = AtomicBitmap::new(size_of_val(buf), page_size);
@@ -2426,14 +2430,13 @@ mod tests {
         let dirty_len = size_of_val(&val);
         let index = 0x1000;
         let dirty_offset = dirty_len * index;
-        let page_size = 0x1000;
 
         let mut buf = vec![0u64; index + 1];
         let mut byte_buf = vec![0u8; index + 1];
 
         // Test `ref_at`.
         {
-            let bitmap = AtomicBitmap::new(buf.len() * size_of_val(&val), page_size);
+            let bitmap = AtomicBitmap::new(buf.len() * size_of_val(&val), DEFAULT_PAGE_SIZE);
             let arr = unsafe {
                 VolatileArrayRef::with_bitmap(
                     buf.as_mut_ptr() as *mut u8,
@@ -2450,7 +2453,7 @@ mod tests {
 
         // Test `store`.
         {
-            let bitmap = AtomicBitmap::new(buf.len() * size_of_val(&val), page_size);
+            let bitmap = AtomicBitmap::new(buf.len() * size_of_val(&val), DEFAULT_PAGE_SIZE);
             let arr = unsafe {
                 VolatileArrayRef::with_bitmap(
                     buf.as_mut_ptr() as *mut u8,
@@ -2467,8 +2470,8 @@ mod tests {
         }
 
         // Test `copy_from` when size_of::<T>() == 1.
-        test_volatile_array_ref_copy_from_tracking(&mut byte_buf, index, page_size);
+        test_volatile_array_ref_copy_from_tracking(&mut byte_buf, index, DEFAULT_PAGE_SIZE);
         // Test `copy_from` when size_of::<T>() > 1.
-        test_volatile_array_ref_copy_from_tracking(&mut buf, index, page_size);
+        test_volatile_array_ref_copy_from_tracking(&mut buf, index, DEFAULT_PAGE_SIZE);
     }
 }


### PR DESCRIPTION
This avoids potential divide by zero error.

Fixes https://github.com/rust-vmm/vm-memory/issues/268

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
