### PR TITLE
Correct the comments for GuestMemory::write_volatile_to

### DIFF
--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -725,9 +725,9 @@ pub trait GuestMemory {
         })
     }
 
-    /// Reads up to `count` bytes from the container at `addr` and writes them it into guest memory.
+    /// Reads up to `count` bytes from guest memory at `addr` and writes them it into an object.
     ///
-    /// Returns the number of bytes written into guest memory.
+    /// Returns the number of bytes copied from guest memory.
     ///
     /// # Arguments
     /// * `addr` - Begin reading from this address.
@@ -782,7 +782,7 @@ pub trait GuestMemory {
         Ok(())
     }
 
-    /// Reads exactly `count` bytes from the container at `addr` and writes them into guest memory.
+    /// Reads exactly `count` bytes from guest memory at `addr` and writes them into an object.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
### Summary of the PR

The comments for `GuestMemory::write_volatile_to` are wrong and need to be fixed.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
