### PR TITLE
atomic_bitmap: use `usize::div_ceil()`

### DIFF
--- a/src/bitmap/backend/atomic_bitmap.rs
+++ b/src/bitmap/backend/atomic_bitmap.rs
@@ -26,13 +26,8 @@ impl AtomicBitmap {
     /// Create a new bitmap of `byte_size`, with one bit per page. This is effectively
     /// rounded up, and we get a new vector of the next multiple of 64 bigger than `bit_size`.
     pub fn new(byte_size: usize, page_size: NonZeroUsize) -> Self {
-        let mut num_pages = byte_size / page_size;
-        if byte_size % page_size > 0 {
-            num_pages += 1;
-        }
-
-        // Adding one entry element more just in case `num_pages` is not a multiple of `64`.
-        let map_size = num_pages / 64 + 1;
+        let num_pages = byte_size.div_ceil(page_size.get());
+        let map_size = num_pages.div_ceil(u64::BITS as usize);
         let map: Vec<AtomicU64> = (0..map_size).map(|_| AtomicU64::new(0)).collect();
 
         AtomicBitmap {


### PR DESCRIPTION
### Summary of the PR

Instead of checking a division remainder, use `usize::div_ceil()`, which will round division up, adding an extra member to the bitmap when needed.

Since at the moment we unconditionally add 1 to `map_size`, this change results in allocating one less `AtomicU64` in some cases.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [X] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- `N/A` All added/changed functionality has a corresponding unit/integration
  test.
- `N/A` All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- `N/A` Any newly added `unsafe` code is properly documented.
