### PR TITLE
Fail build on non 64-bit targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 ### Changed
+- [[#275](https://github.com/rust-vmm/vm-memory/pull/275)] Fail builds on non 64-bit platforms.
 ### Fixed
 ### Removed
 ### Deprecated

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,10 @@
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 
+// We only support 64bit. Fail build when attempting to build other targets
+#[cfg(not(target_pointer_width = "64"))]
+compile_error!("vm-memory only supports 64-bit targets!");
+
 #[macro_use]
 pub mod address;
 pub use address::{Address, AddressValue};


### PR DESCRIPTION
As discussed on Slack and during sync meetings, we should make it explicit that we only support 64bit. While other architectures may be viable to support, currently we assume that usize == u64 and nobody expressed interest in 32bit support.

Closes: #225

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
