### PR TITLE
Update vmm-sys-util to 0.12.1 and prepare 0.14.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,20 @@
 
 ## Upcoming version
 
+### Added
+### Changed
+### Fixed
+### Removed
+### Deprecated
+
+## [v0.14.0]
+
+### Added
 - [[#266](https://github.com/rust-vmm/vm-memory/pull/266)] Derive `Debug` for several
   types that were missing it.
-- [[#274]] Drop `Default` as requirement for `ByteValued`.
+
+### Changed
+- [[#274](https://github.com/rust-vmm/vm-memory/pull/274)] Drop `Default` as requirement for `ByteValued`.
 
 ## [v0.13.1]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ libc = "0.2.39"
 arc-swap = { version = "1.0.0", optional = true }
 bitflags = { version = "2.4.0", optional = true }
 thiserror = "1.0.40"
-vmm-sys-util = { version = "0.11.0", optional = true }
+vmm-sys-util = { version = "0.12.1", optional = true }
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"
@@ -32,7 +32,7 @@ features = ["errhandlingapi", "sysinfoapi"]
 [dev-dependencies]
 criterion = "0.3.0"
 matches = "0.1.0"
-vmm-sys-util = "0.11.0"
+vmm-sys-util = "0.12.1"
 
 [[bench]]
 name = "main"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vm-memory"
-version = "0.13.1"
+version = "0.14.0"
 description = "Safe abstractions for accessing the VM physical memory"
 keywords = ["memory"]
 categories = ["memory-management"]


### PR DESCRIPTION
The vmm-sys-util update brings a fix for a security vulnerability behind
feature-gated code not used by vm-memory (the `with-serde` feature),
see https://github.com/advisories/GHSA-875g-mfp6-g7f9

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
