### PR TITLE
Remove  `GuestMemoryIterator`, replace with GAT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Upcoming version
 
+### Changed
+
+- [[#278](https://github.com/rust-vmm/vm-memory/pull/278) Remove `GuestMemoryIterator` trait,
+  and instead have GuestMemory::iter() return `impl Iterator`.
+
 ## [v0.15.0]
 
 ### Added

--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -422,42 +422,6 @@ impl<M: GuestMemory> GuestAddressSpace for Arc<M> {
     }
 }
 
-/// Lifetime generic associated iterators. The actual iterator type is defined through associated
-/// item `Iter`, for example:
-///
-/// ```
-/// # use std::marker::PhantomData;
-/// # use vm_memory::guest_memory::GuestMemoryIterator;
-/// #
-/// // Declare the relevant Region and Memory types
-/// struct MyGuestRegion {/* fields omitted */}
-/// struct MyGuestMemory {/* fields omitted */}
-///
-/// // Make an Iterator type to iterate over the Regions
-/// # /*
-/// struct MyGuestMemoryIter<'a> {/* fields omitted */}
-/// # */
-/// # struct MyGuestMemoryIter<'a> {
-/// #   _marker: PhantomData<&'a MyGuestRegion>,
-/// # }
-/// impl<'a> Iterator for MyGuestMemoryIter<'a> {
-///     type Item = &'a MyGuestRegion;
-///     fn next(&mut self) -> Option<&'a MyGuestRegion> {
-///         // ...
-/// #       None
-///     }
-/// }
-///
-/// // Associate the Iter type with the Memory type
-/// impl<'a> GuestMemoryIterator<'a, MyGuestRegion> for MyGuestMemory {
-///     type Iter = MyGuestMemoryIter<'a>;
-/// }
-/// ```
-pub trait GuestMemoryIterator<'a, R: 'a> {
-    /// Type of the `iter` method's return value.
-    type Iter: Iterator<Item = &'a R>;
-}
-
 /// `GuestMemory` represents a container for an *immutable* collection of
 /// `GuestMemoryRegion` objects.  `GuestMemory` provides the `Bytes<GuestAddress>`
 /// trait to hide the details of accessing guest memory by physical address.
@@ -470,9 +434,6 @@ pub trait GuestMemoryIterator<'a, R: 'a> {
 pub trait GuestMemory {
     /// Type of objects hosted by the address space.
     type R: GuestMemoryRegion;
-
-    /// Lifetime generic associated iterators. Usually this is just `Self`.
-    type I: for<'a> GuestMemoryIterator<'a, Self::R>;
 
     /// Returns the number of regions in the collection.
     fn num_regions(&self) -> usize;
@@ -533,7 +494,7 @@ pub trait GuestMemory {
     /// assert_eq!(3, total_size)
     /// # }
     /// ```
-    fn iter(&self) -> <Self::I as GuestMemoryIterator<Self::R>>::Iter;
+    fn iter(&self) -> impl Iterator<Item = &Self::R>;
 
     /// Applies two functions, specified as callbacks, on the inner memory regions.
     ///

--- a/src/mmap.rs
+++ b/src/mmap.rs
@@ -24,8 +24,7 @@ use std::sync::Arc;
 use crate::address::Address;
 use crate::bitmap::{Bitmap, BS};
 use crate::guest_memory::{
-    self, FileOffset, GuestAddress, GuestMemory, GuestMemoryIterator, GuestMemoryRegion,
-    GuestUsize, MemoryRegionAddress,
+    self, FileOffset, GuestAddress, GuestMemory, GuestMemoryRegion, GuestUsize, MemoryRegionAddress,
 };
 use crate::volatile_memory::{VolatileMemory, VolatileSlice};
 use crate::{AtomicAccess, Bytes};
@@ -613,27 +612,8 @@ impl<B: Bitmap> GuestMemoryMmap<B> {
     }
 }
 
-/// An iterator over the elements of `GuestMemoryMmap`.
-///
-/// This struct is created by `GuestMemory::iter()`. See its documentation for more.
-#[derive(Debug)]
-pub struct Iter<'a, B>(std::slice::Iter<'a, Arc<GuestRegionMmap<B>>>);
-
-impl<'a, B> Iterator for Iter<'a, B> {
-    type Item = &'a GuestRegionMmap<B>;
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(AsRef::as_ref)
-    }
-}
-
-impl<'a, B: 'a> GuestMemoryIterator<'a, GuestRegionMmap<B>> for GuestMemoryMmap<B> {
-    type Iter = Iter<'a, B>;
-}
-
 impl<B: Bitmap + 'static> GuestMemory for GuestMemoryMmap<B> {
     type R = GuestRegionMmap<B>;
-
-    type I = Self;
 
     fn num_regions(&self) -> usize {
         self.regions.len()
@@ -649,8 +629,8 @@ impl<B: Bitmap + 'static> GuestMemory for GuestMemoryMmap<B> {
         index.map(|x| self.regions[x].as_ref())
     }
 
-    fn iter(&self) -> Iter<B> {
-        Iter(self.regions.iter())
+    fn iter(&self) -> impl Iterator<Item = &Self::R> {
+        self.regions.iter().map(AsRef::as_ref)
     }
 }
 


### PR DESCRIPTION
Use an implicit generic associated type to realize GuestMemory::iter(). This removes the pre-GAT workaround used here to get an iterator that borrows values with the same lifetime as the `&self` parameter to `.iter()`.

This is a follow up from a discussion between @Ablu and me on Slack. I was cleaning up my workspace and decided to just put it out here to get some comments. Note that this requires rustc 1.75.0 to compile.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
