### PR TITLE
fix: Remove 4096B chunk restriction of read/write_volatile_from/into

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 ### Changed
 ### Fixed
+- [[#279](https://github.com/rust-vmm/vm-memory/pull/279)] Remove restriction from `read_volatile_from` and `write_volatile_into`
+  that made it copy data it chunks of 4096.
+
 ### Removed
 ### Deprecated
 

--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -724,8 +724,6 @@ pub trait GuestMemory {
             // Check if something bad happened before doing unsafe things.
             assert!(offset <= count);
 
-            let len = std::cmp::min(len, MAX_ACCESS_CHUNK);
-
             let mut vslice = region.get_slice(caddr, len)?;
 
             src.read_volatile(&mut vslice)
@@ -749,7 +747,6 @@ pub trait GuestMemory {
             // Check if something bad happened before doing unsafe things.
             assert!(offset <= count);
 
-            let len = std::cmp::min(len, MAX_ACCESS_CHUNK);
             let vslice = region.get_slice(caddr, len)?;
 
             // For a non-RAM region, reading could have side effects, so we


### PR DESCRIPTION
Fixes a bug where GuestMemory::read_volatile_from and GuestMemory::write_volatile_into would only copy data in chunks of at most 4096 bytes from/into the underlying stream. The check removed in this commit was errorneously copied from the read_from/write_into functions, which use a temporary buffer to transfer data (and this temporary buffer was capped to 4096 bytes).

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
