### PR TITLE
Update documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,4 +44,4 @@ codegen-units = 1
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs", "--cfg", "feature=\"backend-mmap\"", "--cfg", "feature=\"backend-atomic\""]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,4 @@ codegen-units = 1
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs", "--cfg", "feature=\"backend-mmap\"", "--cfg", "feature=\"backend-atomic\""]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,11 @@
 //! without knowing the implementation details of the VM memory provider. Thus hypervisor
 //! components, such as boot loader, virtual device drivers, virtio backend drivers and vhost
 //! drivers etc, could be shared and reused by multiple hypervisors.
-
 #![deny(clippy::doc_markdown)]
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, allow(unused_attributes))]
 
 // We only support 64bit. Fail build when attempting to build other targets
 #[cfg(not(target_pointer_width = "64"))]
@@ -29,6 +30,7 @@ pub mod address;
 pub use address::{Address, AddressValue};
 
 #[cfg(feature = "backend-atomic")]
+#[cfg_attr(docsrs, doc(cfg(feature = "backend-atomic")))]
 pub mod atomic;
 #[cfg(feature = "backend-atomic")]
 pub use atomic::{GuestMemoryAtomic, GuestMemoryLoadGuard};
@@ -63,7 +65,9 @@ mod mmap_xen;
 mod mmap_windows;
 
 #[cfg(feature = "backend-mmap")]
+#[cfg_attr(docsrs, doc(cfg(feature = "backend-mmap")))]
 pub mod mmap;
+
 #[cfg(feature = "backend-mmap")]
 pub use mmap::{Error, GuestMemoryMmap, GuestRegionMmap, MmapRegion};
 #[cfg(all(feature = "backend-mmap", feature = "xen", unix))]


### PR DESCRIPTION
### Summary of the PR

Annotated modules in lib.rs to indicate their feature dependencies such that it is reflected in the docs, enhancing documentation clarity for users on docs.rs. Added rustdoc-args section 


Building Documentation Locally:

To build the documentation locally with the specified feature flags, use the following command:

```
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --open
```

This command sets the necessary `RUSTDOCFLAGS` to include conditional compilation flags and features specific to our project, ensuring the generated documentation reflects the same level of detail and conditions as seen on docs.rs.


