### PR TITLE
Add build support on riscv64

### DIFF
--- a/src/atomic_integer.rs
+++ b/src/atomic_integer.rs
@@ -60,7 +60,8 @@ impl_atomic_integer_ops!(std::sync::atomic::AtomicI32, i32);
     target_arch = "x86_64",
     target_arch = "aarch64",
     target_arch = "powerpc64",
-    target_arch = "s390x"
+    target_arch = "s390x",
+    target_arch = "riscv64"
 ))]
 impl_atomic_integer_ops!(std::sync::atomic::AtomicI64, i64);
 
@@ -71,7 +72,8 @@ impl_atomic_integer_ops!(std::sync::atomic::AtomicU32, u32);
     target_arch = "x86_64",
     target_arch = "aarch64",
     target_arch = "powerpc64",
-    target_arch = "s390x"
+    target_arch = "s390x",
+    target_arch = "riscv64"
 ))]
 impl_atomic_integer_ops!(std::sync::atomic::AtomicU64, u64);
 

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -191,7 +191,8 @@ impl_atomic_access!(i32, std::sync::atomic::AtomicI32);
     target_arch = "x86_64",
     target_arch = "aarch64",
     target_arch = "powerpc64",
-    target_arch = "s390x"
+    target_arch = "s390x",
+    target_arch = "riscv64"
 ))]
 impl_atomic_access!(i64, std::sync::atomic::AtomicI64);
 
@@ -202,7 +203,8 @@ impl_atomic_access!(u32, std::sync::atomic::AtomicU32);
     target_arch = "x86_64",
     target_arch = "aarch64",
     target_arch = "powerpc64",
-    target_arch = "s390x"
+    target_arch = "s390x",
+    target_arch = "riscv64"
 ))]
 impl_atomic_access!(u64, std::sync::atomic::AtomicU64);
 


### PR DESCRIPTION
### Summary of the PR

This pull request adds support for building the project on RISC-V 64 (riscv64) architectures. Building has been tested successfully on Fedora.

You can test it by building rpm from this repo:
https://src.fedoraproject.org/fork/imbearchild/rpms/rust-vm-memory/tree/rawhide-rv64

(Since Fedora do not have official rv64 support at this moment, you can use a third-party Fedora port from PLCT lab, both OCI image and disk image is available. If you want to use it, please refer to Fedora Wiki for more information on this topic.)

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
