### PR TITLE
feat: support find_arc_region and IntoIterator for GuestMemoryMmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Upcoming version
 
 ### Added
+- [[#293](https://github.com/rust-vmm/vm-memory/pull/293)] Implement `find_arc_region` and `IntoIterator` for `GuestMemoryMmap`.
 ### Changed
 - [[#275](https://github.com/rust-vmm/vm-memory/pull/275)] Fail builds on non 64-bit platforms.
 ### Fixed


### PR DESCRIPTION
This allows GuestMemoryMmap to expose more operation capabilities for GuestRegionMmap. This will make it possible to optimize searches for regions.

### Summary of the PR

Implement `find_arc_region` and `IntoIterator` for `GuestMemoryMmap`.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
