### PR TITLE
atomic_bitmap: support enlarging the bitmap

### DIFF
--- a/src/bitmap/backend/atomic_bitmap.rs
+++ b/src/bitmap/backend/atomic_bitmap.rs
@@ -18,6 +18,7 @@ use crate::mmap::NewBitmap;
 pub struct AtomicBitmap {
     map: Vec<AtomicU64>,
     size: usize,
+    byte_size: usize,
     page_size: NonZeroUsize,
 }
 
@@ -33,6 +34,7 @@ impl AtomicBitmap {
         AtomicBitmap {
             map,
             size: num_pages,
+            byte_size,
             page_size,
         }
     }
@@ -117,6 +119,11 @@ impl AtomicBitmap {
         self.size
     }
 
+    /// Get the size in bytes i.e how many bytes the bitmap can represent, one bit per page.
+    pub fn byte_size(&self) -> usize {
+        self.byte_size
+    }
+
     /// Atomically get and reset the dirty page bitmap.
     pub fn get_and_reset(&self) -> Vec<u64> {
         self.map
@@ -144,6 +151,7 @@ impl Clone for AtomicBitmap {
         AtomicBitmap {
             map,
             size: self.size,
+            byte_size: self.byte_size,
             page_size: self.page_size,
         }
     }

--- a/src/bitmap/backend/atomic_bitmap.rs
+++ b/src/bitmap/backend/atomic_bitmap.rs
@@ -39,6 +39,15 @@ impl AtomicBitmap {
         }
     }
 
+    /// Enlarge this bitmap with enough bits to track `additional_size` additional bytes at page granularity.
+    /// New bits are initialized to zero.
+    pub fn enlarge(&mut self, additional_size: usize) {
+        self.byte_size += additional_size;
+        self.size = self.byte_size.div_ceil(self.page_size.get());
+        let map_size = self.size.div_ceil(u64::BITS as usize);
+        self.map.resize_with(map_size, Default::default);
+    }
+
     /// Is bit `n` set? Bits outside the range of the bitmap are always unset.
     pub fn is_bit_set(&self, index: usize) -> bool {
         if index < self.size {

--- a/src/bitmap/backend/atomic_bitmap.rs
+++ b/src/bitmap/backend/atomic_bitmap.rs
@@ -295,4 +295,44 @@ mod tests {
         let b = AtomicBitmap::new(0x800, DEFAULT_PAGE_SIZE);
         test_bitmap(&b);
     }
+
+    #[test]
+    fn test_bitmap_enlarge() {
+        let mut b = AtomicBitmap::new(8 * 1024, DEFAULT_PAGE_SIZE);
+        assert_eq!(b.len(), 64);
+        b.set_addr_range(128, 129);
+        assert!(!b.is_addr_set(0));
+        assert!(b.is_addr_set(128));
+        assert!(b.is_addr_set(256));
+        assert!(!b.is_addr_set(384));
+
+        b.reset_addr_range(128, 129);
+        assert!(!b.is_addr_set(0));
+        assert!(!b.is_addr_set(128));
+        assert!(!b.is_addr_set(256));
+        assert!(!b.is_addr_set(384));
+        b.set_addr_range(128, 129);
+        b.enlarge(8 * 1024);
+        for i in 65..128 {
+            assert!(!b.is_bit_set(i));
+        }
+        assert_eq!(b.len(), 128);
+        assert!(!b.is_addr_set(0));
+        assert!(b.is_addr_set(128));
+        assert!(b.is_addr_set(256));
+        assert!(!b.is_addr_set(384));
+
+        b.set_bit(55);
+        assert!(b.is_bit_set(55));
+        for i in 65..128 {
+            b.set_bit(i);
+        }
+        for i in 65..128 {
+            assert!(b.is_bit_set(i));
+        }
+        b.reset_addr_range(0, 16 * 1024);
+        for i in 0..128 {
+            assert!(!b.is_bit_set(i));
+        }
+    }
 }


### PR DESCRIPTION
### Summary of the PR

This patch adds the support the enlarge the atomic bitmap.
 Some use cases in cloud-Hypervisor needs to enlarge the bitmap on-demand.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
