### PR TITLE
feat: Implement ReadVolatile and WriteVolatile for TcpStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Upcoming version
 
+### Added
+
+- \[[#304](https://github.com/rust-vmm/vm-memory/pull/304)\] Implement ReadVolatile and WriteVolatile for TcpStream
+
 ## \[v0.16.0\]
 
 ### Added

--- a/src/io.rs
+++ b/src/io.rs
@@ -144,6 +144,7 @@ impl WriteVolatile for Stdout {
 }
 
 impl_read_write_volatile_for_raw_fd!(std::fs::File);
+impl_read_write_volatile_for_raw_fd!(std::net::TcpStream);
 impl_read_write_volatile_for_raw_fd!(std::os::unix::net::UnixStream);
 impl_read_write_volatile_for_raw_fd!(std::os::fd::OwnedFd);
 impl_read_write_volatile_for_raw_fd!(std::os::fd::BorrowedFd<'_>);


### PR DESCRIPTION
Add implementations of the ReadVolatile and WriteVolatile traits for std::net::TcpStream by extending the impl_read_write_volatile_for_raw_fd! macro.