### PR TITLE
Generify parts of mmap.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - \[[#311](https://github.com/rust-vmm/vm-memory/pull/311)\] Allow compiling without the ReadVolatile and WriteVolatile implementations
+- \[[#312](https://github.com/rust-vmm/vm-memory/pull/312)\] `GuestRegionContainer`, a generic container of `GuestMemoryRegion`s, generalizing `GuestMemoryMmap` (which 
+  is now a type alias for `GuestRegionContainer<GuestRegionMmap>`).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   `write_volatile_to` and `write_all_volatile_to` functions from the `GuestMemory` trait to the `Bytes` trait.
 - \[[#312](https://github.com/rust-vmm/vm-memory/pull/312)\]: Give `GuestMemory::find_region` and `GuestMemory::num_regions`
   a default implementation, based on linear search.
+- \[[#312](https://github.com/rust-vmm/vm-memory/pull/312)\]: Provide a marker trait, `GuestMemoryRegionBytes`, which enables a default implementation of `Bytes<MemoryRegionAddress>`
+  for a `GuestMemoryRegion` if implemented.
 
 - \[#324](https:////github.com/rust-vmm/vm-memory/pull/324)\] `GuestMemoryRegion::bitmap()` now returns a `BitmapSlice`. Accessing the full bitmap is now possible only if the type of the memory region is know, for example with `MmapRegion::bitmap()`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@
   a default implementation, based on linear search.
 - \[[#312](https://github.com/rust-vmm/vm-memory/pull/312)\]: Provide a marker trait, `GuestMemoryRegionBytes`, which enables a default implementation of `Bytes<MemoryRegionAddress>`
   for a `GuestMemoryRegion` if implemented.
-
+- \[[#312](https://github.com/rust-vmm/vm-memory/pull/312)\]: Adjust error types returned from `GuestMemoryMmap::from_ranges[_with_files]`
+  and `GuestRegionMmap::from_range` to be separate from the error type returned by `GuestRegionCollection` functions.
+  Change return type of `GuestRegionMmap::new` from `Result` to `Option`.
 - \[#324](https:////github.com/rust-vmm/vm-memory/pull/324)\] `GuestMemoryRegion::bitmap()` now returns a `BitmapSlice`. Accessing the full bitmap is now possible only if the type of the memory region is know, for example with `MmapRegion::bitmap()`.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - \[[#307](https://github.com/rust-vmm/vm-memory/pull/304)\] Move `read_volatile_from`, `read_exact_volatile_from`,
   `write_volatile_to` and `write_all_volatile_to` functions from the `GuestMemory` trait to the `Bytes` trait.
+- \[[#312](https://github.com/rust-vmm/vm-memory/pull/312)\]: Give `GuestMemory::find_region` a default implementation,
+  based on linear search.
 
 - \[#324](https:////github.com/rust-vmm/vm-memory/pull/324)\] `GuestMemoryRegion::bitmap()` now returns a `BitmapSlice`. Accessing the full bitmap is now possible only if the type of the memory region is know, for example with `MmapRegion::bitmap()`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@
 
 - \[[#307](https://github.com/rust-vmm/vm-memory/pull/304)\] Move `read_volatile_from`, `read_exact_volatile_from`,
   `write_volatile_to` and `write_all_volatile_to` functions from the `GuestMemory` trait to the `Bytes` trait.
-- \[[#312](https://github.com/rust-vmm/vm-memory/pull/312)\]: Give `GuestMemory::find_region` a default implementation,
-  based on linear search.
+- \[[#312](https://github.com/rust-vmm/vm-memory/pull/312)\]: Give `GuestMemory::find_region` and `GuestMemory::num_regions`
+  a default implementation, based on linear search.
 
 - \[#324](https:////github.com/rust-vmm/vm-memory/pull/324)\] `GuestMemoryRegion::bitmap()` now returns a `BitmapSlice`. Accessing the full bitmap is now possible only if the type of the memory region is know, for example with `MmapRegion::bitmap()`.
 

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 92.28,
+  "coverage_score": 91.78,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap,backend-atomic,backend-bitmap"
 }

--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -408,7 +408,9 @@ pub trait GuestMemory {
     fn num_regions(&self) -> usize;
 
     /// Returns the region containing the specified address or `None`.
-    fn find_region(&self, addr: GuestAddress) -> Option<&Self::R>;
+    fn find_region(&self, addr: GuestAddress) -> Option<&Self::R> {
+        self.iter().find(|region| addr >= region.start_addr() && addr <= region.last_addr())
+    }
 
     /// Gets an iterator over the entries in the collection.
     ///

--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -405,7 +405,9 @@ pub trait GuestMemory {
     type R: GuestMemoryRegion;
 
     /// Returns the number of regions in the collection.
-    fn num_regions(&self) -> usize;
+    fn num_regions(&self) -> usize {
+        self.iter().count()
+    }
 
     /// Returns the region containing the specified address or `None`.
     fn find_region(&self, addr: GuestAddress) -> Option<&Self::R> {

--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -50,10 +50,11 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use crate::address::{Address, AddressValue};
-use crate::bitmap::{Bitmap, BS, MS};
+use crate::bitmap::MS;
 use crate::bytes::{AtomicAccess, Bytes};
 use crate::io::{ReadVolatile, WriteVolatile};
 use crate::volatile_memory::{self, VolatileSlice};
+use crate::GuestMemoryRegion;
 
 /// Errors associated with handling guest memory accesses.
 #[allow(missing_docs)]
@@ -155,139 +156,6 @@ impl FileOffset {
     /// Returns the start offset within the file.
     pub fn start(&self) -> u64 {
         self.start
-    }
-}
-
-/// Represents a continuous region of guest physical memory.
-#[allow(clippy::len_without_is_empty)]
-pub trait GuestMemoryRegion: Bytes<MemoryRegionAddress, E = Error> {
-    /// Type used for dirty memory tracking.
-    type B: Bitmap;
-
-    /// Returns the size of the region.
-    fn len(&self) -> GuestUsize;
-
-    /// Returns the minimum (inclusive) address managed by the region.
-    fn start_addr(&self) -> GuestAddress;
-
-    /// Returns the maximum (inclusive) address managed by the region.
-    fn last_addr(&self) -> GuestAddress {
-        // unchecked_add is safe as the region bounds were checked when it was created.
-        self.start_addr().unchecked_add(self.len() - 1)
-    }
-
-    /// Borrow the associated `Bitmap` object.
-    fn bitmap(&self) -> BS<'_, Self::B>;
-
-    /// Returns the given address if it is within this region.
-    fn check_address(&self, addr: MemoryRegionAddress) -> Option<MemoryRegionAddress> {
-        if self.address_in_range(addr) {
-            Some(addr)
-        } else {
-            None
-        }
-    }
-
-    /// Returns `true` if the given address is within this region.
-    fn address_in_range(&self, addr: MemoryRegionAddress) -> bool {
-        addr.raw_value() < self.len()
-    }
-
-    /// Returns the address plus the offset if it is in this region.
-    fn checked_offset(
-        &self,
-        base: MemoryRegionAddress,
-        offset: usize,
-    ) -> Option<MemoryRegionAddress> {
-        base.checked_add(offset as u64)
-            .and_then(|addr| self.check_address(addr))
-    }
-
-    /// Tries to convert an absolute address to a relative address within this region.
-    ///
-    /// Returns `None` if `addr` is out of the bounds of this region.
-    fn to_region_addr(&self, addr: GuestAddress) -> Option<MemoryRegionAddress> {
-        addr.checked_offset_from(self.start_addr())
-            .and_then(|offset| self.check_address(MemoryRegionAddress(offset)))
-    }
-
-    /// Returns the host virtual address corresponding to the region address.
-    ///
-    /// Some [`GuestMemory`](trait.GuestMemory.html) implementations, like `GuestMemoryMmap`,
-    /// have the capability to mmap guest address range into host virtual address space for
-    /// direct access, so the corresponding host virtual address may be passed to other subsystems.
-    ///
-    /// # Note
-    /// The underlying guest memory is not protected from memory aliasing, which breaks the
-    /// Rust memory safety model. It's the caller's responsibility to ensure that there's no
-    /// concurrent accesses to the underlying guest memory.
-    fn get_host_address(&self, _addr: MemoryRegionAddress) -> Result<*mut u8> {
-        Err(Error::HostAddressNotAvailable)
-    }
-
-    /// Returns information regarding the file and offset backing this memory region.
-    fn file_offset(&self) -> Option<&FileOffset> {
-        None
-    }
-
-    /// Returns a [`VolatileSlice`](struct.VolatileSlice.html) of `count` bytes starting at
-    /// `offset`.
-    #[allow(unused_variables)]
-    fn get_slice(
-        &self,
-        offset: MemoryRegionAddress,
-        count: usize,
-    ) -> Result<VolatileSlice<BS<Self::B>>> {
-        Err(Error::HostAddressNotAvailable)
-    }
-
-    /// Gets a slice of memory for the entire region that supports volatile access.
-    ///
-    /// # Examples (uses the `backend-mmap` feature)
-    ///
-    /// ```
-    /// # #[cfg(feature = "backend-mmap")]
-    /// # {
-    /// # use vm_memory::{GuestAddress, MmapRegion, GuestRegionMmap, GuestMemoryRegion};
-    /// # use vm_memory::volatile_memory::{VolatileMemory, VolatileSlice, VolatileRef};
-    /// #
-    /// let region = GuestRegionMmap::<()>::from_range(GuestAddress(0x0), 0x400, None)
-    ///     .expect("Could not create guest memory");
-    /// let slice = region
-    ///     .as_volatile_slice()
-    ///     .expect("Could not get volatile slice");
-    ///
-    /// let v = 42u32;
-    /// let r = slice
-    ///     .get_ref::<u32>(0x200)
-    ///     .expect("Could not get reference");
-    /// r.store(v);
-    /// assert_eq!(r.load(), v);
-    /// # }
-    /// ```
-    fn as_volatile_slice(&self) -> Result<VolatileSlice<BS<Self::B>>> {
-        self.get_slice(MemoryRegionAddress(0), self.len() as usize)
-    }
-
-    /// Show if the region is based on the `HugeTLBFS`.
-    /// Returns Some(true) if the region is backed by hugetlbfs.
-    /// None represents that no information is available.
-    ///
-    /// # Examples (uses the `backend-mmap` feature)
-    ///
-    /// ```
-    /// # #[cfg(feature = "backend-mmap")]
-    /// # {
-    /// #   use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap, GuestRegionMmap};
-    /// let addr = GuestAddress(0x1000);
-    /// let mem = GuestMemoryMmap::<()>::from_ranges(&[(addr, 0x1000)]).unwrap();
-    /// let r = mem.find_region(addr).unwrap();
-    /// assert_eq!(r.is_hugetlbfs(), None);
-    /// # }
-    /// ```
-    #[cfg(target_os = "linux")]
-    fn is_hugetlbfs(&self) -> Option<bool> {
-        None
     }
 }
 
@@ -411,7 +279,8 @@ pub trait GuestMemory {
 
     /// Returns the region containing the specified address or `None`.
     fn find_region(&self, addr: GuestAddress) -> Option<&Self::R> {
-        self.iter().find(|region| addr >= region.start_addr() && addr <= region.last_addr())
+        self.iter()
+            .find(|region| addr >= region.start_addr() && addr <= region.last_addr())
     }
 
     /// Gets an iterator over the entries in the collection.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,11 @@ pub use endian::{Be16, Be32, Be64, BeSize, Le16, Le32, Le64, LeSize};
 pub mod guest_memory;
 pub use guest_memory::{
     Error as GuestMemoryError, FileOffset, GuestAddress, GuestAddressSpace, GuestMemory,
-    GuestMemoryRegion, GuestUsize, MemoryRegionAddress, Result as GuestMemoryResult,
+    GuestUsize, MemoryRegionAddress, Result as GuestMemoryResult,
 };
+
+pub mod region;
+pub use region::GuestMemoryRegion;
 
 pub mod io;
 pub use io::{ReadVolatile, WriteVolatile};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub use guest_memory::{
 
 pub mod region;
 pub use region::{
-    GuestMemoryRegion, GuestMemoryRegionBytes, GuestRegionCollection, GuestRegionError as Error,
+    GuestMemoryRegion, GuestMemoryRegionBytes, GuestRegionCollection, GuestRegionCollectionError,
 };
 
 pub mod io;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub use guest_memory::{
 };
 
 pub mod region;
-pub use region::GuestMemoryRegion;
+pub use region::{GuestMemoryRegion, GuestRegionCollection, GuestRegionError as Error};
 
 pub mod io;
 pub use io::{ReadVolatile, WriteVolatile};
@@ -60,7 +60,7 @@ pub use io::{ReadVolatile, WriteVolatile};
 pub mod mmap;
 
 #[cfg(feature = "backend-mmap")]
-pub use mmap::{Error, GuestMemoryMmap, GuestRegionMmap, MmapRegion};
+pub use mmap::{GuestMemoryMmap, GuestRegionMmap, MmapRegion};
 #[cfg(all(feature = "backend-mmap", feature = "xen", target_family = "unix"))]
 pub use mmap::{MmapRange, MmapXenFlags};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,9 @@ pub use guest_memory::{
 };
 
 pub mod region;
-pub use region::{GuestMemoryRegion, GuestRegionCollection, GuestRegionError as Error};
+pub use region::{
+    GuestMemoryRegion, GuestMemoryRegionBytes, GuestRegionCollection, GuestRegionError as Error,
+};
 
 pub mod io;
 pub use io::{ReadVolatile, WriteVolatile};

--- a/src/mmap/mod.rs
+++ b/src/mmap/mod.rs
@@ -21,8 +21,9 @@ use std::sync::Arc;
 use crate::address::Address;
 use crate::bitmap::{Bitmap, BS};
 use crate::guest_memory::{
-    self, FileOffset, GuestAddress, GuestMemory, GuestMemoryRegion, GuestUsize, MemoryRegionAddress,
+    self, FileOffset, GuestAddress, GuestMemory, GuestUsize, MemoryRegionAddress,
 };
+use crate::region::GuestMemoryRegion;
 use crate::volatile_memory::{VolatileMemory, VolatileSlice};
 use crate::{AtomicAccess, Bytes, ReadVolatile, WriteVolatile};
 

--- a/src/mmap/unix.rs
+++ b/src/mmap/unix.rs
@@ -561,7 +561,7 @@ mod tests {
             prot,
             flags | libc::MAP_FIXED,
         );
-        assert_eq!(format!("{:?}", r.unwrap_err()), "MapFixed");
+        assert!(matches!(r.unwrap_err(), Error::MapFixed));
 
         // Let's resize the file.
         assert_eq!(unsafe { libc::ftruncate(a.as_raw_fd(), 1024 * 10) }, 0);
@@ -606,7 +606,7 @@ mod tests {
         let flags = libc::MAP_NORESERVE | libc::MAP_PRIVATE;
 
         let r = unsafe { MmapRegion::build_raw((addr + 1) as *mut u8, size, prot, flags) };
-        assert_eq!(format!("{:?}", r.unwrap_err()), "InvalidPointer");
+        assert!(matches!(r.unwrap_err(), Error::InvalidPointer));
 
         let r = unsafe { MmapRegion::build_raw(addr as *mut u8, size, prot, flags).unwrap() };
 

--- a/src/mmap/xen.rs
+++ b/src/mmap/xen.rs
@@ -1069,26 +1069,18 @@ mod tests {
         range.mmap_flags = 16;
 
         let r = MmapXen::new(&range);
-        assert_eq!(
-            format!("{:?}", r.unwrap_err()),
-            format!("MmapFlags({})", range.mmap_flags),
-        );
+        assert!(matches!(r.unwrap_err(), Error::MmapFlags(flags) if flags == range.mmap_flags));
 
         range.mmap_flags = MmapXenFlags::FOREIGN.bits() | MmapXenFlags::GRANT.bits();
         let r = MmapXen::new(&range);
-        assert_eq!(
-            format!("{:?}", r.unwrap_err()),
-            format!("MmapFlags({:x})", MmapXenFlags::ALL.bits()),
+        assert!(
+            matches!(r.unwrap_err(), Error::MmapFlags(flags) if flags == MmapXenFlags::ALL.bits())
         );
 
         range.mmap_flags = MmapXenFlags::FOREIGN.bits() | MmapXenFlags::NO_ADVANCE_MAP.bits();
         let r = MmapXen::new(&range);
-        assert_eq!(
-            format!("{:?}", r.unwrap_err()),
-            format!(
-                "MmapFlags({:x})",
-                MmapXenFlags::NO_ADVANCE_MAP.bits() | MmapXenFlags::FOREIGN.bits(),
-            ),
+        assert!(
+            matches!(r.unwrap_err(), Error::MmapFlags(flags) if flags ==  MmapXenFlags::NO_ADVANCE_MAP.bits() | MmapXenFlags::FOREIGN.bits())
         );
     }
 
@@ -1124,17 +1116,17 @@ mod tests {
         range.file_offset = Some(FileOffset::new(TempFile::new().unwrap().into_file(), 0));
         range.prot = None;
         let r = MmapXenForeign::new(&range);
-        assert_eq!(format!("{:?}", r.unwrap_err()), "UnexpectedError");
+        assert!(matches!(r.unwrap_err(), Error::UnexpectedError));
 
         let mut range = MmapRange::initialized(true);
         range.flags = None;
         let r = MmapXenForeign::new(&range);
-        assert_eq!(format!("{:?}", r.unwrap_err()), "UnexpectedError");
+        assert!(matches!(r.unwrap_err(), Error::UnexpectedError));
 
         let mut range = MmapRange::initialized(true);
         range.file_offset = Some(FileOffset::new(TempFile::new().unwrap().into_file(), 1));
         let r = MmapXenForeign::new(&range);
-        assert_eq!(format!("{:?}", r.unwrap_err()), "InvalidOffsetLength");
+        assert!(matches!(r.unwrap_err(), Error::InvalidOffsetLength));
 
         let mut range = MmapRange::initialized(true);
         range.size = 0;
@@ -1156,7 +1148,7 @@ mod tests {
         let mut range = MmapRange::initialized(true);
         range.prot = None;
         let r = MmapXenGrant::new(&range, MmapXenFlags::empty());
-        assert_eq!(format!("{:?}", r.unwrap_err()), "UnexpectedError");
+        assert!(matches!(r.unwrap_err(), Error::UnexpectedError));
 
         let mut range = MmapRange::initialized(true);
         range.prot = None;
@@ -1166,12 +1158,12 @@ mod tests {
         let mut range = MmapRange::initialized(true);
         range.flags = None;
         let r = MmapXenGrant::new(&range, MmapXenFlags::NO_ADVANCE_MAP);
-        assert_eq!(format!("{:?}", r.unwrap_err()), "UnexpectedError");
+        assert!(matches!(r.unwrap_err(), Error::UnexpectedError));
 
         let mut range = MmapRange::initialized(true);
         range.file_offset = Some(FileOffset::new(TempFile::new().unwrap().into_file(), 1));
         let r = MmapXenGrant::new(&range, MmapXenFlags::NO_ADVANCE_MAP);
-        assert_eq!(format!("{:?}", r.unwrap_err()), "InvalidOffsetLength");
+        assert!(matches!(r.unwrap_err(), Error::InvalidOffsetLength));
 
         let mut range = MmapRange::initialized(true);
         range.size = 0;

--- a/src/region.rs
+++ b/src/region.rs
@@ -1,0 +1,141 @@
+//! Module containing abstracts for dealing with contiguous regions of guest memory
+
+use crate::bitmap::{Bitmap, BS};
+use crate::guest_memory::Error;
+use crate::guest_memory::Result;
+use crate::{
+    Address, Bytes, FileOffset, GuestAddress, GuestUsize, MemoryRegionAddress, VolatileSlice,
+};
+
+/// Represents a continuous region of guest physical memory.
+#[allow(clippy::len_without_is_empty)]
+pub trait GuestMemoryRegion: Bytes<MemoryRegionAddress, E = Error> {
+    /// Type used for dirty memory tracking.
+    type B: Bitmap;
+
+    /// Returns the size of the region.
+    fn len(&self) -> GuestUsize;
+
+    /// Returns the minimum (inclusive) address managed by the region.
+    fn start_addr(&self) -> GuestAddress;
+
+    /// Returns the maximum (inclusive) address managed by the region.
+    fn last_addr(&self) -> GuestAddress {
+        // unchecked_add is safe as the region bounds were checked when it was created.
+        self.start_addr().unchecked_add(self.len() - 1)
+    }
+
+    /// Borrow the associated `Bitmap` object.
+    fn bitmap(&self) -> BS<'_, Self::B>;
+
+    /// Returns the given address if it is within this region.
+    fn check_address(&self, addr: MemoryRegionAddress) -> Option<MemoryRegionAddress> {
+        if self.address_in_range(addr) {
+            Some(addr)
+        } else {
+            None
+        }
+    }
+
+    /// Returns `true` if the given address is within this region.
+    fn address_in_range(&self, addr: MemoryRegionAddress) -> bool {
+        addr.raw_value() < self.len()
+    }
+
+    /// Returns the address plus the offset if it is in this region.
+    fn checked_offset(
+        &self,
+        base: MemoryRegionAddress,
+        offset: usize,
+    ) -> Option<MemoryRegionAddress> {
+        base.checked_add(offset as u64)
+            .and_then(|addr| self.check_address(addr))
+    }
+
+    /// Tries to convert an absolute address to a relative address within this region.
+    ///
+    /// Returns `None` if `addr` is out of the bounds of this region.
+    fn to_region_addr(&self, addr: GuestAddress) -> Option<MemoryRegionAddress> {
+        addr.checked_offset_from(self.start_addr())
+            .and_then(|offset| self.check_address(MemoryRegionAddress(offset)))
+    }
+
+    /// Returns the host virtual address corresponding to the region address.
+    ///
+    /// Some [`GuestMemory`](trait.GuestMemory.html) implementations, like `GuestMemoryMmap`,
+    /// have the capability to mmap guest address range into host virtual address space for
+    /// direct access, so the corresponding host virtual address may be passed to other subsystems.
+    ///
+    /// # Note
+    /// The underlying guest memory is not protected from memory aliasing, which breaks the
+    /// Rust memory safety model. It's the caller's responsibility to ensure that there's no
+    /// concurrent accesses to the underlying guest memory.
+    fn get_host_address(&self, _addr: MemoryRegionAddress) -> Result<*mut u8> {
+        Err(Error::HostAddressNotAvailable)
+    }
+
+    /// Returns information regarding the file and offset backing this memory region.
+    fn file_offset(&self) -> Option<&FileOffset> {
+        None
+    }
+
+    /// Returns a [`VolatileSlice`](struct.VolatileSlice.html) of `count` bytes starting at
+    /// `offset`.
+    #[allow(unused_variables)]
+    fn get_slice(
+        &self,
+        offset: MemoryRegionAddress,
+        count: usize,
+    ) -> Result<VolatileSlice<BS<Self::B>>> {
+        Err(Error::HostAddressNotAvailable)
+    }
+
+    /// Gets a slice of memory for the entire region that supports volatile access.
+    ///
+    /// # Examples (uses the `backend-mmap` feature)
+    ///
+    /// ```
+    /// # #[cfg(feature = "backend-mmap")]
+    /// # {
+    /// # use vm_memory::{GuestAddress, MmapRegion, GuestRegionMmap, GuestMemoryRegion};
+    /// # use vm_memory::volatile_memory::{VolatileMemory, VolatileSlice, VolatileRef};
+    /// #
+    /// let region = GuestRegionMmap::<()>::from_range(GuestAddress(0x0), 0x400, None)
+    ///     .expect("Could not create guest memory");
+    /// let slice = region
+    ///     .as_volatile_slice()
+    ///     .expect("Could not get volatile slice");
+    ///
+    /// let v = 42u32;
+    /// let r = slice
+    ///     .get_ref::<u32>(0x200)
+    ///     .expect("Could not get reference");
+    /// r.store(v);
+    /// assert_eq!(r.load(), v);
+    /// # }
+    /// ```
+    fn as_volatile_slice(&self) -> Result<VolatileSlice<BS<Self::B>>> {
+        self.get_slice(MemoryRegionAddress(0), self.len() as usize)
+    }
+
+    /// Show if the region is based on the `HugeTLBFS`.
+    /// Returns Some(true) if the region is backed by hugetlbfs.
+    /// None represents that no information is available.
+    ///
+    /// # Examples (uses the `backend-mmap` feature)
+    ///
+    /// ```
+    /// # #[cfg(feature = "backend-mmap")]
+    /// # {
+    /// #   use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap, GuestRegionMmap};
+    /// let addr = GuestAddress(0x1000);
+    /// let mem = GuestMemoryMmap::<()>::from_ranges(&[(addr, 0x1000)]).unwrap();
+    /// let r = mem.find_region(addr).unwrap();
+    /// assert_eq!(r.is_hugetlbfs(), None);
+    /// # }
+    /// ```
+    #[cfg(target_os = "linux")]
+    fn is_hugetlbfs(&self) -> Option<bool> {
+        None
+    }
+}

--- a/src/region.rs
+++ b/src/region.rs
@@ -478,7 +478,7 @@ impl<R: GuestMemoryRegionBytes> Bytes<MemoryRegionAddress> for R {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use crate::region::{GuestMemoryRegionBytes, GuestRegionError};
     use crate::{
         Address, GuestAddress, GuestMemory, GuestMemoryRegion, GuestRegionCollection, GuestUsize,
@@ -486,9 +486,9 @@ mod tests {
     use std::sync::Arc;
 
     #[derive(Debug, PartialEq, Eq)]
-    struct MockRegion {
-        start: GuestAddress,
-        len: GuestUsize,
+    pub(crate) struct MockRegion {
+        pub(crate) start: GuestAddress,
+        pub(crate) len: GuestUsize,
     }
 
     impl GuestMemoryRegion for MockRegion {
@@ -507,7 +507,7 @@ mod tests {
 
     impl GuestMemoryRegionBytes for MockRegion {}
 
-    type Collection = GuestRegionCollection<MockRegion>;
+    pub(crate) type Collection = GuestRegionCollection<MockRegion>;
 
     fn check_guest_memory_mmap(
         maybe_guest_mem: Result<Collection, GuestRegionError>,
@@ -535,7 +535,7 @@ mod tests {
         }
     }
 
-    fn new_guest_memory_collection_from_regions(
+    pub(crate) fn new_guest_memory_collection_from_regions(
         regions_summary: &[(GuestAddress, u64)],
     ) -> Result<Collection, GuestRegionError> {
         Collection::from_regions(

--- a/src/region.rs
+++ b/src/region.rs
@@ -4,8 +4,10 @@ use crate::bitmap::{Bitmap, BS};
 use crate::guest_memory::Error;
 use crate::guest_memory::Result;
 use crate::{
-    Address, Bytes, FileOffset, GuestAddress, GuestUsize, MemoryRegionAddress, VolatileSlice,
+    Address, Bytes, FileOffset, GuestAddress, GuestMemory, GuestUsize, MemoryRegionAddress,
+    VolatileSlice,
 };
+use std::sync::Arc;
 
 /// Represents a continuous region of guest physical memory.
 #[allow(clippy::len_without_is_empty)]
@@ -137,5 +139,163 @@ pub trait GuestMemoryRegion: Bytes<MemoryRegionAddress, E = Error> {
     #[cfg(target_os = "linux")]
     fn is_hugetlbfs(&self) -> Option<bool> {
         None
+    }
+}
+
+/// Errors that can occur when dealing with [`GuestRegion`]s, or collections thereof
+#[derive(Debug, thiserror::Error)]
+pub enum GuestRegionError {
+    /// Adding the guest base address to the length of the underlying mapping resulted
+    /// in an overflow.
+    #[error("Adding the guest base address to the length of the underlying mapping resulted in an overflow")]
+    #[cfg(feature = "backend-mmap")]
+    InvalidGuestRegion,
+    /// Error creating a `MmapRegion` object.
+    #[error("{0}")]
+    #[cfg(feature = "backend-mmap")]
+    MmapRegion(crate::mmap::MmapRegionError),
+    /// No memory region found.
+    #[error("No memory region found")]
+    NoMemoryRegion,
+    /// Some of the memory regions intersect with each other.
+    #[error("Some of the memory regions intersect with each other")]
+    MemoryRegionOverlap,
+    /// The provided memory regions haven't been sorted.
+    #[error("The provided memory regions haven't been sorted")]
+    UnsortedMemoryRegions,
+}
+
+/// [`GuestMemory`](trait.GuestMemory.html) implementation based on a homogeneous collection
+/// of [`GuestMemoryRegion`] implementations.
+///
+/// Represents a sorted set of non-overlapping physical guest memory regions.
+#[derive(Debug)]
+pub struct GuestRegionCollection<R> {
+    regions: Vec<Arc<R>>,
+}
+
+impl<R> Default for GuestRegionCollection<R> {
+    fn default() -> Self {
+        Self {
+            regions: Vec::new(),
+        }
+    }
+}
+
+impl<R> Clone for GuestRegionCollection<R> {
+    fn clone(&self) -> Self {
+        GuestRegionCollection {
+            regions: self.regions.iter().map(Arc::clone).collect(),
+        }
+    }
+}
+
+impl<R: GuestMemoryRegion> GuestRegionCollection<R> {
+    /// Creates an empty `GuestMemoryMmap` instance.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates a new [`GuestRegionCollection`] from a vector of regions.
+    ///
+    /// # Arguments
+    ///
+    /// * `regions` - The vector of regions.
+    ///               The regions shouldn't overlap, and they should be sorted
+    ///               by the starting address.
+    pub fn from_regions(mut regions: Vec<R>) -> std::result::Result<Self, GuestRegionError> {
+        Self::from_arc_regions(regions.drain(..).map(Arc::new).collect())
+    }
+
+    /// Creates a new [`GuestRegionCollection`] from a vector of Arc regions.
+    ///
+    /// Similar to the constructor `from_regions()` as it returns a
+    /// [`GuestRegionCollection`]. The need for this constructor is to provide a way for
+    /// consumer of this API to create a new [`GuestRegionCollection`] based on existing
+    /// regions coming from an existing [`GuestRegionCollection`] instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `regions` - The vector of `Arc` regions.
+    ///               The regions shouldn't overlap and they should be sorted
+    ///               by the starting address.
+    pub fn from_arc_regions(regions: Vec<Arc<R>>) -> std::result::Result<Self, GuestRegionError> {
+        if regions.is_empty() {
+            return Err(GuestRegionError::NoMemoryRegion);
+        }
+
+        for window in regions.windows(2) {
+            let prev = &window[0];
+            let next = &window[1];
+
+            if prev.start_addr() > next.start_addr() {
+                return Err(GuestRegionError::UnsortedMemoryRegions);
+            }
+
+            if prev.last_addr() >= next.start_addr() {
+                return Err(GuestRegionError::MemoryRegionOverlap);
+            }
+        }
+
+        Ok(Self { regions })
+    }
+
+    /// Insert a region into the `GuestMemoryMmap` object and return a new `GuestMemoryMmap`.
+    ///
+    /// # Arguments
+    /// * `region`: the memory region to insert into the guest memory object.
+    pub fn insert_region(
+        &self,
+        region: Arc<R>,
+    ) -> std::result::Result<GuestRegionCollection<R>, GuestRegionError> {
+        let mut regions = self.regions.clone();
+        regions.push(region);
+        regions.sort_by_key(|x| x.start_addr());
+
+        Self::from_arc_regions(regions)
+    }
+
+    /// Remove a region from the [`GuestRegionCollection`] object and return a new `GuestRegionCollection`
+    /// on success, together with the removed region.
+    ///
+    /// # Arguments
+    /// * `base`: base address of the region to be removed
+    /// * `size`: size of the region to be removed
+    pub fn remove_region(
+        &self,
+        base: GuestAddress,
+        size: GuestUsize,
+    ) -> std::result::Result<(GuestRegionCollection<R>, Arc<R>), GuestRegionError> {
+        if let Ok(region_index) = self.regions.binary_search_by_key(&base, |x| x.start_addr()) {
+            if self.regions.get(region_index).unwrap().len() == size {
+                let mut regions = self.regions.clone();
+                let region = regions.remove(region_index);
+                return Ok((Self { regions }, region));
+            }
+        }
+
+        Err(GuestRegionError::NoMemoryRegion)
+    }
+}
+
+impl<R: GuestMemoryRegion> GuestMemory for GuestRegionCollection<R> {
+    type R = R;
+
+    fn num_regions(&self) -> usize {
+        self.regions.len()
+    }
+
+    fn find_region(&self, addr: GuestAddress) -> Option<&R> {
+        let index = match self.regions.binary_search_by_key(&addr, |x| x.start_addr()) {
+            Ok(x) => Some(x),
+            // Within the closest region with starting address < addr
+            Err(x) if (x > 0 && addr <= self.regions[x - 1].last_addr()) => Some(x - 1),
+            _ => None,
+        };
+        index.map(|x| self.regions[x].as_ref())
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &Self::R> {
+        self.regions.iter().map(AsRef::as_ref)
     }
 }

--- a/src/region.rs
+++ b/src/region.rs
@@ -476,3 +476,328 @@ impl<R: GuestMemoryRegionBytes> Bytes<MemoryRegionAddress> for R {
             .and_then(|s| s.load(addr.raw_value() as usize, order).map_err(Into::into))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::region::{GuestMemoryRegionBytes, GuestRegionError};
+    use crate::{
+        Address, GuestAddress, GuestMemory, GuestMemoryRegion, GuestRegionCollection, GuestUsize,
+    };
+    use std::sync::Arc;
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct MockRegion {
+        start: GuestAddress,
+        len: GuestUsize,
+    }
+
+    impl GuestMemoryRegion for MockRegion {
+        type B = ();
+
+        fn len(&self) -> GuestUsize {
+            self.len
+        }
+
+        fn start_addr(&self) -> GuestAddress {
+            self.start
+        }
+
+        fn bitmap(&self) {}
+    }
+
+    impl GuestMemoryRegionBytes for MockRegion {}
+
+    type Collection = GuestRegionCollection<MockRegion>;
+
+    fn check_guest_memory_mmap(
+        maybe_guest_mem: Result<Collection, GuestRegionError>,
+        expected_regions_summary: &[(GuestAddress, u64)],
+    ) {
+        assert!(maybe_guest_mem.is_ok());
+
+        let guest_mem = maybe_guest_mem.unwrap();
+        assert_eq!(guest_mem.num_regions(), expected_regions_summary.len());
+        let maybe_last_mem_reg = expected_regions_summary.last();
+        if let Some((region_addr, region_size)) = maybe_last_mem_reg {
+            let mut last_addr = region_addr.unchecked_add(*region_size);
+            if last_addr.raw_value() != 0 {
+                last_addr = last_addr.unchecked_sub(1);
+            }
+            assert_eq!(guest_mem.last_addr(), last_addr);
+        }
+        for ((region_addr, region_size), mmap) in
+            expected_regions_summary.iter().zip(guest_mem.iter())
+        {
+            assert_eq!(region_addr, &mmap.start);
+            assert_eq!(region_size, &mmap.len);
+
+            assert!(guest_mem.find_region(*region_addr).is_some());
+        }
+    }
+
+    fn new_guest_memory_collection_from_regions(
+        regions_summary: &[(GuestAddress, u64)],
+    ) -> Result<Collection, GuestRegionError> {
+        Collection::from_regions(
+            regions_summary
+                .iter()
+                .map(|&(start, len)| MockRegion { start, len })
+                .collect(),
+        )
+    }
+
+    fn new_guest_memory_collection_from_arc_regions(
+        regions_summary: &[(GuestAddress, u64)],
+    ) -> Result<Collection, GuestRegionError> {
+        Collection::from_arc_regions(
+            regions_summary
+                .iter()
+                .map(|&(start, len)| Arc::new(MockRegion { start, len }))
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn test_no_memory_region() {
+        let regions_summary = [];
+
+        assert!(matches!(
+            new_guest_memory_collection_from_regions(&regions_summary).unwrap_err(),
+            GuestRegionError::NoMemoryRegion
+        ));
+        assert!(matches!(
+            new_guest_memory_collection_from_arc_regions(&regions_summary).unwrap_err(),
+            GuestRegionError::NoMemoryRegion
+        ));
+    }
+
+    #[test]
+    fn test_overlapping_memory_regions() {
+        let regions_summary = [(GuestAddress(0), 100), (GuestAddress(99), 100)];
+
+        assert!(matches!(
+            new_guest_memory_collection_from_regions(&regions_summary).unwrap_err(),
+            GuestRegionError::MemoryRegionOverlap
+        ));
+        assert!(matches!(
+            new_guest_memory_collection_from_arc_regions(&regions_summary).unwrap_err(),
+            GuestRegionError::MemoryRegionOverlap
+        ));
+    }
+
+    #[test]
+    fn test_unsorted_memory_regions() {
+        let regions_summary = [(GuestAddress(100), 100), (GuestAddress(0), 100)];
+
+        assert!(matches!(
+            new_guest_memory_collection_from_regions(&regions_summary).unwrap_err(),
+            GuestRegionError::UnsortedMemoryRegions
+        ));
+        assert!(matches!(
+            new_guest_memory_collection_from_arc_regions(&regions_summary).unwrap_err(),
+            GuestRegionError::UnsortedMemoryRegions
+        ));
+    }
+
+    #[test]
+    fn test_valid_memory_regions() {
+        let regions_summary = [(GuestAddress(0), 100), (GuestAddress(100), 100)];
+
+        let guest_mem = Collection::new();
+        assert_eq!(guest_mem.num_regions(), 0);
+
+        check_guest_memory_mmap(
+            new_guest_memory_collection_from_regions(&regions_summary),
+            &regions_summary,
+        );
+
+        check_guest_memory_mmap(
+            new_guest_memory_collection_from_arc_regions(&regions_summary),
+            &regions_summary,
+        );
+    }
+
+    #[test]
+    fn test_mmap_insert_region() {
+        let region_size = 0x1000;
+        let regions = vec![
+            (GuestAddress(0x0), region_size),
+            (GuestAddress(0x10_0000), region_size),
+        ];
+        let mem_orig = new_guest_memory_collection_from_regions(&regions).unwrap();
+        let mut gm = mem_orig.clone();
+        assert_eq!(mem_orig.num_regions(), 2);
+
+        let new_regions = [
+            (GuestAddress(0x8000), 0x1000),
+            (GuestAddress(0x4000), 0x1000),
+            (GuestAddress(0xc000), 0x1000),
+        ];
+
+        for (start, len) in new_regions {
+            gm = gm
+                .insert_region(Arc::new(MockRegion { start, len }))
+                .unwrap();
+        }
+
+        gm.insert_region(Arc::new(MockRegion {
+            start: GuestAddress(0xc000),
+            len: 0x1000,
+        }))
+        .unwrap_err();
+
+        assert_eq!(mem_orig.num_regions(), 2);
+        assert_eq!(gm.num_regions(), 5);
+
+        let regions = gm.iter().collect::<Vec<_>>();
+
+        assert_eq!(regions[0].start_addr(), GuestAddress(0x0000));
+        assert_eq!(regions[1].start_addr(), GuestAddress(0x4000));
+        assert_eq!(regions[2].start_addr(), GuestAddress(0x8000));
+        assert_eq!(regions[3].start_addr(), GuestAddress(0xc000));
+        assert_eq!(regions[4].start_addr(), GuestAddress(0x10_0000));
+    }
+
+    #[test]
+    fn test_mmap_remove_region() {
+        let region_size = 0x1000;
+        let regions = vec![
+            (GuestAddress(0x0), region_size),
+            (GuestAddress(0x10_0000), region_size),
+        ];
+        let mem_orig = new_guest_memory_collection_from_regions(&regions).unwrap();
+        let gm = mem_orig.clone();
+        assert_eq!(mem_orig.num_regions(), 2);
+
+        gm.remove_region(GuestAddress(0), 128).unwrap_err();
+        gm.remove_region(GuestAddress(0x4000), 128).unwrap_err();
+        let (gm, region) = gm.remove_region(GuestAddress(0x10_0000), 0x1000).unwrap();
+
+        assert_eq!(mem_orig.num_regions(), 2);
+        assert_eq!(gm.num_regions(), 1);
+
+        assert_eq!(gm.iter().next().unwrap().start_addr(), GuestAddress(0x0000));
+        assert_eq!(region.start_addr(), GuestAddress(0x10_0000));
+    }
+
+    #[test]
+    fn test_iter() {
+        let region_size = 0x400;
+        let regions = vec![
+            (GuestAddress(0x0), region_size),
+            (GuestAddress(0x1000), region_size),
+        ];
+        let mut iterated_regions = Vec::new();
+        let gm = new_guest_memory_collection_from_regions(&regions).unwrap();
+
+        for region in gm.iter() {
+            assert_eq!(region.len(), region_size as GuestUsize);
+        }
+
+        for region in gm.iter() {
+            iterated_regions.push((region.start_addr(), region.len()));
+        }
+        assert_eq!(regions, iterated_regions);
+
+        assert!(regions
+            .iter()
+            .map(|x| (x.0, x.1))
+            .eq(iterated_regions.iter().copied()));
+
+        let mmap_regions = gm.iter().collect::<Vec<_>>();
+
+        assert_eq!(mmap_regions[0].start, regions[0].0);
+        assert_eq!(mmap_regions[1].start, regions[1].0);
+    }
+
+    #[test]
+    fn test_address_in_range() {
+        let start_addr1 = GuestAddress(0x0);
+        let start_addr2 = GuestAddress(0x800);
+        let guest_mem =
+            new_guest_memory_collection_from_regions(&[(start_addr1, 0x400), (start_addr2, 0x400)])
+                .unwrap();
+
+        assert!(guest_mem.address_in_range(GuestAddress(0x200)));
+        assert!(!guest_mem.address_in_range(GuestAddress(0x600)));
+        assert!(guest_mem.address_in_range(GuestAddress(0xa00)));
+        assert!(!guest_mem.address_in_range(GuestAddress(0xc00)));
+    }
+
+    #[test]
+    fn test_check_address() {
+        let start_addr1 = GuestAddress(0x0);
+        let start_addr2 = GuestAddress(0x800);
+        let guest_mem =
+            new_guest_memory_collection_from_regions(&[(start_addr1, 0x400), (start_addr2, 0x400)])
+                .unwrap();
+
+        assert_eq!(
+            guest_mem.check_address(GuestAddress(0x200)),
+            Some(GuestAddress(0x200))
+        );
+        assert_eq!(guest_mem.check_address(GuestAddress(0x600)), None);
+        assert_eq!(
+            guest_mem.check_address(GuestAddress(0xa00)),
+            Some(GuestAddress(0xa00))
+        );
+        assert_eq!(guest_mem.check_address(GuestAddress(0xc00)), None);
+    }
+
+    #[test]
+    fn test_checked_offset() {
+        let start_addr1 = GuestAddress(0);
+        let start_addr2 = GuestAddress(0x800);
+        let start_addr3 = GuestAddress(0xc00);
+        let guest_mem = new_guest_memory_collection_from_regions(&[
+            (start_addr1, 0x400),
+            (start_addr2, 0x400),
+            (start_addr3, 0x400),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            guest_mem.checked_offset(start_addr1, 0x200),
+            Some(GuestAddress(0x200))
+        );
+        assert_eq!(
+            guest_mem.checked_offset(start_addr1, 0xa00),
+            Some(GuestAddress(0xa00))
+        );
+        assert_eq!(
+            guest_mem.checked_offset(start_addr2, 0x7ff),
+            Some(GuestAddress(0xfff))
+        );
+        assert_eq!(guest_mem.checked_offset(start_addr2, 0xc00), None);
+        assert_eq!(guest_mem.checked_offset(start_addr1, usize::MAX), None);
+
+        assert_eq!(guest_mem.checked_offset(start_addr1, 0x400), None);
+        assert_eq!(
+            guest_mem.checked_offset(start_addr1, 0x400 - 1),
+            Some(GuestAddress(0x400 - 1))
+        );
+    }
+
+    #[test]
+    fn test_check_range() {
+        let start_addr1 = GuestAddress(0);
+        let start_addr2 = GuestAddress(0x800);
+        let start_addr3 = GuestAddress(0xc00);
+        let guest_mem = new_guest_memory_collection_from_regions(&[
+            (start_addr1, 0x400),
+            (start_addr2, 0x400),
+            (start_addr3, 0x400),
+        ])
+        .unwrap();
+
+        assert!(guest_mem.check_range(start_addr1, 0x0));
+        assert!(guest_mem.check_range(start_addr1, 0x200));
+        assert!(guest_mem.check_range(start_addr1, 0x400));
+        assert!(!guest_mem.check_range(start_addr1, 0xa00));
+        assert!(guest_mem.check_range(start_addr2, 0x7ff));
+        assert!(guest_mem.check_range(start_addr2, 0x800));
+        assert!(!guest_mem.check_range(start_addr2, 0x801));
+        assert!(!guest_mem.check_range(start_addr2, 0xc00));
+        assert!(!guest_mem.check_range(start_addr1, usize::MAX));
+    }
+}

--- a/src/volatile_memory.rs
+++ b/src/volatile_memory.rs
@@ -1489,58 +1489,6 @@ mod tests {
     }
 
     #[test]
-    fn test_display_error() {
-        assert_eq!(
-            format!("{}", Error::OutOfBounds { addr: 0x10 }),
-            "address 0x10 is out of bounds"
-        );
-
-        assert_eq!(
-            format!(
-                "{}",
-                Error::Overflow {
-                    base: 0x0,
-                    offset: 0x10
-                }
-            ),
-            "address 0x0 offset by 0x10 would overflow"
-        );
-
-        assert_eq!(
-            format!(
-                "{}",
-                Error::TooBig {
-                    nelements: 100_000,
-                    size: 1_000_000_000
-                }
-            ),
-            "100000 elements of size 1000000000 would overflow a usize"
-        );
-
-        assert_eq!(
-            format!(
-                "{}",
-                Error::Misaligned {
-                    addr: 0x4,
-                    alignment: 8
-                }
-            ),
-            "address 0x4 is not aligned to 8"
-        );
-
-        assert_eq!(
-            format!(
-                "{}",
-                Error::PartialBuffer {
-                    expected: 100,
-                    completed: 90
-                }
-            ),
-            "only used 90 bytes in 100 long buffer"
-        );
-    }
-
-    #[test]
     fn misaligned_ref() {
         let mut a = [0u8; 3];
         let a_ref = VolatileSlice::from(&mut a[..]);


### PR DESCRIPTION
### Summary of the PR

Mainly, add the concept of a `GuestRegionCollection`, which just manages a list of some `GuestMemoryRegion` impls. Functionality wise, it offers the same implementations as `GuestMemoryMmap`. As a result, turn `GuestMemoryMmap` into a type alias for `GuestRegionCollection` with a fixed `R = GuestRegionMmap`.

While we're at it, generalize the `impl Bytes for GuestRegionMmap` into `impl<R: GuestMemoryRegion> Bytes for R`, because really that impls didn't actually make use of any specifics of the `GuestRegionMmap` struct.

This PR is the backward-compatible subset of #317. In that context, it is a first step towards resolving the incompatibility between the unix and xen features (currently, the code in `mmap.rs` only works if exactly one of the modules `mmap_windows`, `mmap_xen` and `mmap_unix` exist, since they all define roughly the same types which are then imported by the `mmap` module without renames). However, short-term is is also a required step for enabling things like https://github.com/rust-vmm/vm-memory/issues/315 without necessarily requiring changes in core vm-memory code.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
