### PR TITLE
refactor: Move `NewBitmap` trait to `bitmap` module

### DIFF
--- a/src/bitmap/backend/atomic_bitmap.rs
+++ b/src/bitmap/backend/atomic_bitmap.rs
@@ -6,10 +6,7 @@
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use crate::bitmap::{Bitmap, RefSlice, WithBitmapSlice};
-
-#[cfg(feature = "backend-mmap")]
-use crate::mmap::NewBitmap;
+use crate::bitmap::{Bitmap, NewBitmap, RefSlice, WithBitmapSlice};
 
 /// `AtomicBitmap` implements a simple bit map on the page level with test and set operations.
 /// It is page-size aware, so it converts addresses to page numbers before setting or clearing
@@ -191,7 +188,6 @@ impl Default for AtomicBitmap {
     }
 }
 
-#[cfg(feature = "backend-mmap")]
 impl NewBitmap for AtomicBitmap {
     fn with_len(len: usize) -> Self {
         #[cfg(target_family = "unix")]

--- a/src/bitmap/backend/atomic_bitmap_arc.rs
+++ b/src/bitmap/backend/atomic_bitmap_arc.rs
@@ -4,10 +4,7 @@
 use std::ops::Deref;
 use std::sync::Arc;
 
-use crate::bitmap::{ArcSlice, AtomicBitmap, Bitmap, WithBitmapSlice};
-
-#[cfg(feature = "backend-mmap")]
-use crate::mmap::NewBitmap;
+use crate::bitmap::{ArcSlice, AtomicBitmap, Bitmap, NewBitmap, WithBitmapSlice};
 
 /// A `Bitmap` implementation that's based on an atomically reference counted handle to an
 /// `AtomicBitmap` object.
@@ -65,7 +62,6 @@ impl Default for AtomicBitmapArc {
     }
 }
 
-#[cfg(feature = "backend-mmap")]
 impl NewBitmap for AtomicBitmapArc {
     fn with_len(len: usize) -> Self {
         Self::new(AtomicBitmap::with_len(len))

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -47,6 +47,13 @@ pub trait Bitmap: for<'a> WithBitmapSlice<'a> {
     fn slice_at(&self, offset: usize) -> <Self as WithBitmapSlice>::S;
 }
 
+/// A `Bitmap` that can be created starting from an initial size.
+// Cannot be a part of the Bitmap trait itself because it cannot be implemented for BaseSlice
+pub trait NewBitmap: Bitmap + Default {
+    /// Create a new object based on the specified length in bytes.
+    fn with_len(len: usize) -> Self;
+}
+
 /// A no-op `Bitmap` implementation that can be provided for backends that do not actually
 /// require the tracking functionality.
 impl WithBitmapSlice<'_> for () {
@@ -63,6 +70,10 @@ impl Bitmap for () {
     }
 
     fn slice_at(&self, _offset: usize) -> Self {}
+}
+
+impl NewBitmap for () {
+    fn with_len(_len: usize) -> Self {}
 }
 
 /// A `Bitmap` and `BitmapSlice` implementation for `Option<B>`.

--- a/src/mmap/mod.rs
+++ b/src/mmap/mod.rs
@@ -28,6 +28,9 @@ use crate::guest_memory::{
 use crate::volatile_memory::{VolatileMemory, VolatileSlice};
 use crate::{AtomicAccess, Bytes, ReadVolatile, WriteVolatile};
 
+// re-export for backward compat, as the trait used to be defined in mmap.rs
+pub use crate::bitmap::NewBitmap;
+
 #[cfg(all(not(feature = "xen"), target_family = "unix"))]
 mod unix;
 
@@ -47,16 +50,6 @@ pub use xen::{Error as MmapRegionError, MmapRange, MmapRegion, MmapXenFlags};
 pub use std::io::Error as MmapRegionError;
 #[cfg(target_family = "windows")]
 pub use windows::MmapRegion;
-
-/// A `Bitmap` that can be created starting from an initial size.
-pub trait NewBitmap: Bitmap + Default {
-    /// Create a new object based on the specified length in bytes.
-    fn with_len(len: usize) -> Self;
-}
-
-impl NewBitmap for () {
-    fn with_len(_len: usize) -> Self {}
-}
 
 /// Errors that can occur when creating a memory map.
 #[derive(Debug, thiserror::Error)]

--- a/src/mmap/unix.rs
+++ b/src/mmap/unix.rs
@@ -15,9 +15,9 @@ use std::os::unix::io::AsRawFd;
 use std::ptr::null_mut;
 use std::result;
 
-use crate::bitmap::{Bitmap, BS};
+use crate::bitmap::{Bitmap, NewBitmap, BS};
 use crate::guest_memory::FileOffset;
-use crate::mmap::{check_file_offset, NewBitmap};
+use crate::mmap::check_file_offset;
 use crate::volatile_memory::{self, VolatileMemory, VolatileSlice};
 
 /// Error conditions that may arise when creating a new `MmapRegion` object.

--- a/src/mmap/windows.rs
+++ b/src/mmap/windows.rs
@@ -12,9 +12,8 @@ use libc::{c_void, size_t};
 
 use winapi::um::errhandlingapi::GetLastError;
 
-use crate::bitmap::{Bitmap, BS};
+use crate::bitmap::{Bitmap, NewBitmap, BS};
 use crate::guest_memory::FileOffset;
-use crate::mmap::NewBitmap;
 use crate::volatile_memory::{self, compute_offset, VolatileMemory, VolatileSlice};
 
 #[allow(non_snake_case)]

--- a/src/mmap/xen.rs
+++ b/src/mmap/xen.rs
@@ -24,9 +24,9 @@ use vmm_sys_util::ioctl::ioctl_with_ref;
 #[cfg(test)]
 use tests::ioctl_with_ref;
 
-use crate::bitmap::{Bitmap, BS};
+use crate::bitmap::{Bitmap, NewBitmap, BS};
 use crate::guest_memory::{FileOffset, GuestAddress};
-use crate::mmap::{check_file_offset, NewBitmap};
+use crate::mmap::check_file_offset;
 use crate::volatile_memory::{self, VolatileMemory, VolatileSlice};
 
 /// Error conditions that may arise when creating a new `MmapRegion` object.


### PR DESCRIPTION
There is really no reason (at least that I can see) for this to be defined in `mmap.rs`, and for it to be gated behind the backend-mmap feature.

While we're at it, add a comment explaining why this cannot be part of the normal `Bitmap` trait.

Add a public reexport from mmap.rs anyway for backwards compat reasons. No functional change.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
