### PR TITLE
Use stat instead of seek to determine file size

### DIFF
--- a/src/mmap_unix.rs
+++ b/src/mmap_unix.rs
@@ -41,12 +41,9 @@ pub enum Error {
     /// The `mmap` call returned an error.
     #[error("{0}")]
     Mmap(io::Error),
-    /// Seeking the end of the file returned an error.
-    #[error("Error seeking the end of the file: {0}")]
-    SeekEnd(io::Error),
-    /// Seeking the start of the file returned an error.
-    #[error("Error seeking the start of the file: {0}")]
-    SeekStart(io::Error),
+    /// Calling [`File::metadata`] returned an error
+    #[error("Error determining file size: {0}")]
+    Stat(io::Error),
 }
 
 pub type Result<T> = result::Result<T, Error>;

--- a/src/mmap_xen.rs
+++ b/src/mmap_xen.rs
@@ -44,12 +44,9 @@ pub enum Error {
     /// The `mmap` call returned an error.
     #[error("{0}")]
     Mmap(io::Error),
-    /// Seeking the end of the file returned an error.
-    #[error("Error seeking the end of the file: {0}")]
-    SeekEnd(io::Error),
-    /// Seeking the start of the file returned an error.
-    #[error("Error seeking the start of the file: {0}")]
-    SeekStart(io::Error),
+    /// Calling [`File::metadata`] returned an error.
+    #[error("Error determining file size: {0}")]
+    Stat(io::Error),
     /// Invalid file offset.
     #[error("Invalid file offset")]
     InvalidFileOffset,


### PR DESCRIPTION
When constructing a MmapRegion that is backed by a `File`, we sanity check that the size of the file passed in is sufficiently large given the offset / length requested of mmap. Do this check using stat instead of seek, as stat is supported on more file descriptors (particularly, it is supported on guest_memfd, while seek isnt).

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
