### PR TITLE
mmap: drop file-offset checking, defer to `mmap(2)` instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
   `Bytes::write_to`, `Bytes::write_all_to`, `GuestMemory::as_slice`, `GuestMemory::as_slice_mut`, `GuestMemory::with_regions`, 
   `GuestMemory::with_regions_mut`, `GuestMemory::map_and_fold`, `VolatileSlice::as_ptr`, `VolatileRef::as_ptr`, and
   `VolatileArrayRef::as_ptr`.
+- \[[#320](https://github.com/rust-vmm/vm-memory/pull/320)\] Drop `check_file_offset` check when using  `MmapRegionBuilder`.
+  The `mmap(2)` syscall itself already validates that offset and length are valid, and trying to replicate this check
+  in userspace ended up being imperfect.
 
 ## \[v0.16.1\]
 

--- a/src/mmap/xen.rs
+++ b/src/mmap/xen.rs
@@ -26,7 +26,6 @@ use tests::ioctl_with_ref;
 
 use crate::bitmap::{Bitmap, NewBitmap, BS};
 use crate::guest_memory::{FileOffset, GuestAddress};
-use crate::mmap::check_file_offset;
 use crate::volatile_memory::{self, VolatileMemory, VolatileSlice};
 
 /// Error conditions that may arise when creating a new `MmapRegion` object.
@@ -44,12 +43,6 @@ pub enum Error {
     /// The `mmap` call returned an error.
     #[error("{0}")]
     Mmap(io::Error),
-    /// Seeking the end of the file returned an error.
-    #[error("Error seeking the end of the file: {0}")]
-    SeekEnd(io::Error),
-    /// Seeking the start of the file returned an error.
-    #[error("Error seeking the start of the file: {0}")]
-    SeekStart(io::Error),
     /// Invalid file offset.
     #[error("Invalid file offset")]
     InvalidFileOffset,
@@ -524,7 +517,6 @@ struct MmapXenUnix(MmapUnix);
 impl MmapXenUnix {
     fn new(range: &MmapRange) -> Result<Self> {
         let (fd, offset) = if let Some(ref f_off) = range.file_offset {
-            check_file_offset(f_off, range.size)?;
             (f_off.file().as_raw_fd(), f_off.start())
         } else {
             (-1, 0)


### PR DESCRIPTION
When mmap-ing a file-like object, vm-memory was trying to validate the
the range [offset, offset+len) was valid in the file. However, our
homegrown check had lots of edge cases where it gave false-positives
(e.g. it rejected things that should really be working, such as vfio
devices, or fds that cannot be seeked like guest_memfd), and trying to
implement a check that works for all of these is in the end wasted
effort anyway, because the kernel validates all this as part of the mmap
syscall anyway. So just drop these checks in favor of failing at
mmap-time.

See also https://github.com/rust-vmm/vm-memory/issues/195#issuecomment-2754783866

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
