### PR TITLE
io: implement [Read|Write]Volatile for &File and co

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -127,7 +127,7 @@ pub trait WriteVolatile {
 // We explicitly implement our traits for [`std::fs::File`] and [`std::os::unix::net::UnixStream`]
 // instead of providing blanket implementation for [`AsRawFd`] due to trait coherence limitations: A
 // blanket implementation would prevent us from providing implementations for `&mut [u8]` below, as
-// "an upstream crate could implement AsRawFd for &mut [u8]`.
+// "an upstream crate could implement AsRawFd for &mut [u8]".
 
 macro_rules! impl_read_write_volatile_for_raw_fd {
     ($raw_fd_ty:ty) => {
@@ -142,12 +142,32 @@ macro_rules! impl_read_write_volatile_for_raw_fd {
         }
 
         #[cfg(feature = "rawfd")]
+        impl ReadVolatile for &$raw_fd_ty {
+            fn read_volatile<B: BitmapSlice>(
+                &mut self,
+                buf: &mut VolatileSlice<B>,
+            ) -> Result<usize, VolatileMemoryError> {
+                read_volatile_raw_fd(*self, buf)
+            }
+        }
+
+        #[cfg(feature = "rawfd")]
         impl WriteVolatile for $raw_fd_ty {
             fn write_volatile<B: BitmapSlice>(
                 &mut self,
                 buf: &VolatileSlice<B>,
             ) -> Result<usize, VolatileMemoryError> {
                 write_volatile_raw_fd(self, buf)
+            }
+        }
+
+        #[cfg(feature = "rawfd")]
+        impl WriteVolatile for &$raw_fd_ty {
+            fn write_volatile<B: BitmapSlice>(
+                &mut self,
+                buf: &VolatileSlice<B>,
+            ) -> Result<usize, VolatileMemoryError> {
+                write_volatile_raw_fd(*self, buf)
             }
         }
     };
@@ -163,6 +183,16 @@ impl WriteVolatile for Stdout {
     }
 }
 
+#[cfg(feature = "rawfd")]
+impl WriteVolatile for &Stdout {
+    fn write_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &VolatileSlice<B>,
+    ) -> Result<usize, VolatileMemoryError> {
+        write_volatile_raw_fd(*self, buf)
+    }
+}
+
 impl_read_write_volatile_for_raw_fd!(std::fs::File);
 impl_read_write_volatile_for_raw_fd!(std::net::TcpStream);
 impl_read_write_volatile_for_raw_fd!(std::os::unix::net::UnixStream);
@@ -175,7 +205,7 @@ impl_read_write_volatile_for_raw_fd!(std::os::fd::BorrowedFd<'_>);
 /// Returns the numbers of bytes read.
 #[cfg(feature = "rawfd")]
 fn read_volatile_raw_fd<Fd: AsRawFd>(
-    raw_fd: &mut Fd,
+    raw_fd: &Fd,
     buf: &mut VolatileSlice<impl BitmapSlice>,
 ) -> Result<usize, VolatileMemoryError> {
     let fd = raw_fd.as_raw_fd();
@@ -206,7 +236,7 @@ fn read_volatile_raw_fd<Fd: AsRawFd>(
 /// Returns the numbers of bytes written.
 #[cfg(feature = "rawfd")]
 fn write_volatile_raw_fd<Fd: AsRawFd>(
-    raw_fd: &mut Fd,
+    raw_fd: &Fd,
     buf: &VolatileSlice<impl BitmapSlice>,
 ) -> Result<usize, VolatileMemoryError> {
     let fd = raw_fd.as_raw_fd();


### PR DESCRIPTION
Implement these traits for references to types that implement them, e.g. &File, &TcpStream, &UnixStream, &Stdout, etc. This mirrors the standard library implementations and allows calling read/write methods from contexts where no mutable reference is available.

There's probably something more clever we can do with the traits to avoid some repetition, but really, isn't not that bad imo.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
