### PR TITLE
Global dirty bitmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - \[[#307](https://github.com/rust-vmm/vm-memory/pull/304)\] Move `read_volatile_from`, `read_exact_volatile_from`,
   `write_volatile_to` and `write_all_volatile_to` functions from the `GuestMemory` trait to the `Bytes` trait.
 
+- \[#324](https:////github.com/rust-vmm/vm-memory/pull/324)\] `GuestMemoryRegion::bitmap()` now returns a `BitmapSlice`. Accessing the full bitmap is now possible only if the type of the memory region is know, for example with `MmapRegion::bitmap()`.
+
 ### Removed
 
 - \[[#307](https://github.com/rust-vmm/vm-memory/pull/304)\] Remove deprecated functions `Bytes::read_from`, `Bytes::read_exact_from`,

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -293,13 +293,13 @@ pub(crate) mod tests {
 
         let slice = region.get_slice(dirty_addr, dirty_len).unwrap();
 
-        assert!(range_is_clean(region.bitmap(), 0, region.len() as usize));
+        assert!(range_is_clean(&region.bitmap(), 0, region.len() as usize));
         assert!(range_is_clean(slice.bitmap(), 0, dirty_len));
 
         region.write_obj(val, dirty_addr).unwrap();
 
         assert!(range_is_dirty(
-            region.bitmap(),
+            &region.bitmap(),
             dirty_addr.0 as usize,
             dirty_len
         ));
@@ -312,7 +312,7 @@ pub(crate) mod tests {
         test_bytes(
             region,
             |r: &R, start: usize, len: usize, clean: bool| {
-                check_range(r.bitmap(), start, len, clean)
+                check_range(&r.bitmap(), start, len, clean)
             },
             |offset| MemoryRegionAddress(offset as u64),
             0x1000,
@@ -334,13 +334,13 @@ pub(crate) mod tests {
         let (region, region_addr) = m.to_region_addr(dirty_addr).unwrap();
         let slice = m.get_slice(dirty_addr, dirty_len).unwrap();
 
-        assert!(range_is_clean(region.bitmap(), 0, region.len() as usize));
+        assert!(range_is_clean(&region.bitmap(), 0, region.len() as usize));
         assert!(range_is_clean(slice.bitmap(), 0, dirty_len));
 
         m.write_obj(val, dirty_addr).unwrap();
 
         assert!(range_is_dirty(
-            region.bitmap(),
+            &region.bitmap(),
             region_addr.0 as usize,
             dirty_len
         ));
@@ -354,7 +354,7 @@ pub(crate) mod tests {
         let check_range_closure = |m: &M, start: usize, len: usize, clean: bool| -> bool {
             let mut check_result = true;
             m.try_access(len, GuestAddress(start as u64), |_, size, reg_addr, reg| {
-                if !check_range(reg.bitmap(), reg_addr.0 as usize, size, clean) {
+                if !check_range(&reg.bitmap(), reg_addr.0 as usize, size, clean) {
                     check_result = false;
                 }
                 Ok(size)

--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -177,7 +177,7 @@ pub trait GuestMemoryRegion: Bytes<MemoryRegionAddress, E = Error> {
     }
 
     /// Borrow the associated `Bitmap` object.
-    fn bitmap(&self) -> &Self::B;
+    fn bitmap(&self) -> BS<'_, Self::B>;
 
     /// Returns the given address if it is within this region.
     fn check_address(&self, addr: MemoryRegionAddress) -> Option<MemoryRegionAddress> {

--- a/src/mmap/mod.rs
+++ b/src/mmap/mod.rs
@@ -327,8 +327,8 @@ impl<B: Bitmap> GuestMemoryRegion for GuestRegionMmap<B> {
         self.guest_base
     }
 
-    fn bitmap(&self) -> &Self::B {
-        self.mapping.bitmap()
+    fn bitmap(&self) -> BS<'_, Self::B> {
+        self.mapping.bitmap().slice_at(0)
     }
 
     fn get_host_address(&self, addr: MemoryRegionAddress) -> guest_memory::Result<*mut u8> {


### PR DESCRIPTION
### Summary of the PR

QEMU uses a global bitmap, with each RAM region using an offset into it.  This could be easily represented if bitmap() returned a `BaseSlice<&'static GlobalBitmap>`, but there is a problem: `bitmap()` currently wants to return a reference to the bitmap!
    
So change it to always return a slice, like `VolatileMemory` already does.  This is more flexible, and in general it isn't going to affect performance  because using `bitmap()` is pretty niche; it's much more common to use `VolatileMemory::get_slice()` which already builds a `BitmapSlice`.

Because this is a breaking change, I tried to see how much it breaks. I tried building cloud-hypervisor and all the places that needed `bitmap() -> &Self::B` actually knew the type of the region. So it only needed a few extra `*` to go from the GuestRegionMmap to the MmapRegion.

### Example changes to clients

- [x]  rust-vmm/vhost#294
- [x] cloud-hypervisor/cloud-hypervisor#7084

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
