### PR TITLE
build(deps): bump `vmm-sys-util` to 0.14.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ libc = { version = "0.2.39", optional = true }
 arc-swap = { version = "1.0.0", optional = true }
 bitflags = { version = "2.4.0", optional = true }
 thiserror = "1.0.40"
-vmm-sys-util = { version = "0.12.1", optional = true }
+vmm-sys-util = { version = ">=0.12.1,<=0.14.0", optional = true }
 
 [target.'cfg(target_family = "windows")'.dependencies.winapi]
 version = "0.3"
@@ -33,7 +33,7 @@ features = ["errhandlingapi", "sysinfoapi"]
 [dev-dependencies]
 criterion = "0.5.0"
 matches = "0.1.0"
-vmm-sys-util = "0.12.1"
+vmm-sys-util = "0.14.0"
 
 [[bench]]
 name = "main"


### PR DESCRIPTION
### Summary of the PR

Updates `vmm-sys-util` to 0.14.0
- [Release notes](https://github.com/rust-vmm/vmm-sys-util/releases)
- [Changelog](https://github.com/rust-vmm/vmm-sys-util/blob/main/CHANGELOG.md)
- [Commits](rust-vmm/vmm-sys-util@v0.12.1...v0.14.0)

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
