### PR TITLE
add from_raw_ptr for AtomicBitmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - \[[#311](https://github.com/rust-vmm/vm-memory/pull/311)\] Allow compiling without the ReadVolatile and WriteVolatile implementations
+- \[[#xxx](https://github.com/rust-vmm/vm-memory/pull/xxx)\] Add `from_raw_ptr` to `AtomicBitmap`
 
 ### Changed
 


### PR DESCRIPTION
### Summary of the PR

Add `from_raw_ptr` method to `AtomicBitmap`.
This is useful when using `AtomicBitmap` while interacting with interfaces that have a binary interface that relies on the in-memory representation of the bitmap, eg Linux kernel.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
