### PR TITLE
refactor(test): use assert_matches! in tests

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -246,15 +246,16 @@ pub trait Bytes<A> {
     ///
     /// ```rust
     /// # use vm_memory::{Bytes, VolatileMemoryError, VolatileSlice};
+    /// # use matches::assert_matches;
     /// let mut arr = [1, 2, 3, 4, 5];
     /// let slice = VolatileSlice::from(arr.as_mut_slice());
     ///
     /// assert_eq!(slice.write(&[1, 2, 3], 0).unwrap(), 3);
     /// assert_eq!(slice.write(&[1, 2, 3], 3).unwrap(), 2);
-    /// assert!(matches!(
+    /// assert_matches!(
     ///     slice.write(&[1, 2, 3], 5).unwrap_err(),
     ///     VolatileMemoryError::OutOfBounds { addr: 5 }
-    /// ));
+    /// );
     /// assert_eq!(slice.write(&[], 5).unwrap(), 0);
     /// ```
     fn write(&self, buf: &[u8], addr: A) -> Result<usize, Self::E>;

--- a/src/mmap/mod.rs
+++ b/src/mmap/mod.rs
@@ -230,6 +230,8 @@ mod tests {
     use std::{fs::File, path::Path};
     use vmm_sys_util::tempfile::TempFile;
 
+    use matches::assert_matches;
+
     type GuestRegionMmap = super::GuestRegionMmap<()>;
     type GuestMemoryMmap = super::GuestRegionCollection<GuestRegionMmap>;
     type MmapRegion = super::MmapRegion<()>;
@@ -379,13 +381,13 @@ mod tests {
         for gm in gm_list.iter() {
             let val1: u64 = 0xaa55_aa55_aa55_aa55;
             let val2: u64 = 0x55aa_55aa_55aa_55aa;
-            assert!(matches!(
+            assert_matches!(
                 gm.write_obj(val1, bad_addr).unwrap_err(),
                 GuestMemoryError::InvalidGuestAddress(addr) if addr == bad_addr
-            ));
-            assert!(matches!(
+            );
+            assert_matches!(
                 gm.write_obj(val1, bad_addr2).unwrap_err(),
-                GuestMemoryError::PartialBuffer { expected, completed} if expected == size_of::<u64>() && completed == max_addr.checked_offset_from(bad_addr2).unwrap() as usize));
+                GuestMemoryError::PartialBuffer { expected, completed } if expected == size_of::<u64>() && completed == max_addr.checked_offset_from(bad_addr2).unwrap() as usize);
 
             gm.write_obj(val1, GuestAddress(0x500)).unwrap();
             gm.write_obj(val2, GuestAddress(0x1000 + 32)).unwrap();

--- a/src/mmap/unix.rs
+++ b/src/mmap/unix.rs
@@ -445,6 +445,8 @@ mod tests {
     #[cfg(feature = "backend-bitmap")]
     use crate::bitmap::AtomicBitmap;
 
+    use matches::assert_matches;
+
     type MmapRegion = super::MmapRegion<()>;
 
     impl Error {
@@ -551,9 +553,7 @@ mod tests {
             prot,
             flags,
         );
-        assert!(
-            matches!(r.unwrap_err(), Error::Mmap(err) if err.raw_os_error() == Some(libc::EINVAL))
-        );
+        assert_matches!(r.unwrap_err(), Error::Mmap(err) if err.raw_os_error() == Some(libc::EINVAL));
 
         // MAP_FIXED was specified among the flags.
         let r = MmapRegion::build(
@@ -562,7 +562,7 @@ mod tests {
             prot,
             flags | libc::MAP_FIXED,
         );
-        assert!(matches!(r.unwrap_err(), Error::MapFixed));
+        assert_matches!(r.unwrap_err(), Error::MapFixed);
 
         // Let's resize the file.
         assert_eq!(unsafe { libc::ftruncate(a.as_raw_fd(), 1024 * 10) }, 0);
@@ -607,7 +607,7 @@ mod tests {
         let flags = libc::MAP_NORESERVE | libc::MAP_PRIVATE;
 
         let r = unsafe { MmapRegion::build_raw((addr + 1) as *mut u8, size, prot, flags) };
-        assert!(matches!(r.unwrap_err(), Error::InvalidPointer));
+        assert_matches!(r.unwrap_err(), Error::InvalidPointer);
 
         let r = unsafe { MmapRegion::build_raw(addr as *mut u8, size, prot, flags).unwrap() };
 

--- a/src/mmap/xen.rs
+++ b/src/mmap/xen.rs
@@ -1020,6 +1020,7 @@ mod tests {
     #![allow(clippy::undocumented_unsafe_blocks)]
 
     use super::*;
+    use matches::assert_matches;
     use vmm_sys_util::tempfile::TempFile;
 
     // Adding a helper method to extract the errno within an Error::Mmap(e), or return a
@@ -1069,19 +1070,15 @@ mod tests {
         range.mmap_flags = 16;
 
         let r = MmapXen::new(&range);
-        assert!(matches!(r.unwrap_err(), Error::MmapFlags(flags) if flags == range.mmap_flags));
+        assert_matches!(r.unwrap_err(), Error::MmapFlags(flags) if flags == range.mmap_flags);
 
         range.mmap_flags = MmapXenFlags::FOREIGN.bits() | MmapXenFlags::GRANT.bits();
         let r = MmapXen::new(&range);
-        assert!(
-            matches!(r.unwrap_err(), Error::MmapFlags(flags) if flags == MmapXenFlags::ALL.bits())
-        );
+        assert_matches!(r.unwrap_err(), Error::MmapFlags(flags) if flags == MmapXenFlags::ALL.bits());
 
         range.mmap_flags = MmapXenFlags::FOREIGN.bits() | MmapXenFlags::NO_ADVANCE_MAP.bits();
         let r = MmapXen::new(&range);
-        assert!(
-            matches!(r.unwrap_err(), Error::MmapFlags(flags) if flags ==  MmapXenFlags::NO_ADVANCE_MAP.bits() | MmapXenFlags::FOREIGN.bits())
-        );
+        assert_matches!(r.unwrap_err(), Error::MmapFlags(flags) if flags ==  MmapXenFlags::NO_ADVANCE_MAP.bits() | MmapXenFlags::FOREIGN.bits());
     }
 
     #[test]
@@ -1116,17 +1113,17 @@ mod tests {
         range.file_offset = Some(FileOffset::new(TempFile::new().unwrap().into_file(), 0));
         range.prot = None;
         let r = MmapXenForeign::new(&range);
-        assert!(matches!(r.unwrap_err(), Error::UnexpectedError));
+        assert_matches!(r.unwrap_err(), Error::UnexpectedError);
 
         let mut range = MmapRange::initialized(true);
         range.flags = None;
         let r = MmapXenForeign::new(&range);
-        assert!(matches!(r.unwrap_err(), Error::UnexpectedError));
+        assert_matches!(r.unwrap_err(), Error::UnexpectedError);
 
         let mut range = MmapRange::initialized(true);
         range.file_offset = Some(FileOffset::new(TempFile::new().unwrap().into_file(), 1));
         let r = MmapXenForeign::new(&range);
-        assert!(matches!(r.unwrap_err(), Error::InvalidOffsetLength));
+        assert_matches!(r.unwrap_err(), Error::InvalidOffsetLength);
 
         let mut range = MmapRange::initialized(true);
         range.size = 0;
@@ -1148,7 +1145,7 @@ mod tests {
         let mut range = MmapRange::initialized(true);
         range.prot = None;
         let r = MmapXenGrant::new(&range, MmapXenFlags::empty());
-        assert!(matches!(r.unwrap_err(), Error::UnexpectedError));
+        assert_matches!(r.unwrap_err(), Error::UnexpectedError);
 
         let mut range = MmapRange::initialized(true);
         range.prot = None;
@@ -1158,12 +1155,12 @@ mod tests {
         let mut range = MmapRange::initialized(true);
         range.flags = None;
         let r = MmapXenGrant::new(&range, MmapXenFlags::NO_ADVANCE_MAP);
-        assert!(matches!(r.unwrap_err(), Error::UnexpectedError));
+        assert_matches!(r.unwrap_err(), Error::UnexpectedError);
 
         let mut range = MmapRange::initialized(true);
         range.file_offset = Some(FileOffset::new(TempFile::new().unwrap().into_file(), 1));
         let r = MmapXenGrant::new(&range, MmapXenFlags::NO_ADVANCE_MAP);
-        assert!(matches!(r.unwrap_err(), Error::InvalidOffsetLength));
+        assert_matches!(r.unwrap_err(), Error::InvalidOffsetLength);
 
         let mut range = MmapRange::initialized(true);
         range.size = 0;

--- a/src/region.rs
+++ b/src/region.rs
@@ -478,6 +478,7 @@ pub(crate) mod tests {
     use crate::{
         Address, GuestAddress, GuestMemory, GuestMemoryRegion, GuestRegionCollection, GuestUsize,
     };
+    use matches::assert_matches;
     use std::sync::Arc;
 
     #[derive(Debug, PartialEq, Eq)]
@@ -556,42 +557,42 @@ pub(crate) mod tests {
     fn test_no_memory_region() {
         let regions_summary = [];
 
-        assert!(matches!(
+        assert_matches!(
             new_guest_memory_collection_from_regions(&regions_summary).unwrap_err(),
             GuestRegionCollectionError::NoMemoryRegion
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             new_guest_memory_collection_from_arc_regions(&regions_summary).unwrap_err(),
             GuestRegionCollectionError::NoMemoryRegion
-        ));
+        );
     }
 
     #[test]
     fn test_overlapping_memory_regions() {
         let regions_summary = [(GuestAddress(0), 100), (GuestAddress(99), 100)];
 
-        assert!(matches!(
+        assert_matches!(
             new_guest_memory_collection_from_regions(&regions_summary).unwrap_err(),
             GuestRegionCollectionError::MemoryRegionOverlap
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             new_guest_memory_collection_from_arc_regions(&regions_summary).unwrap_err(),
             GuestRegionCollectionError::MemoryRegionOverlap
-        ));
+        );
     }
 
     #[test]
     fn test_unsorted_memory_regions() {
         let regions_summary = [(GuestAddress(100), 100), (GuestAddress(0), 100)];
 
-        assert!(matches!(
+        assert_matches!(
             new_guest_memory_collection_from_regions(&regions_summary).unwrap_err(),
             GuestRegionCollectionError::UnsortedMemoryRegions
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             new_guest_memory_collection_from_arc_regions(&regions_summary).unwrap_err(),
             GuestRegionCollectionError::UnsortedMemoryRegions
-        ));
+        );
     }
 
     #[test]


### PR DESCRIPTION
Use assert_matches!() from our matches dev-dependency instead of assert!(matches!()), to improve the failure messages of tests.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
