### PR TITLE
Make GuestAddressSpace always cloneable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - \[[#312](https://github.com/rust-vmm/vm-memory/pull/312)\] `GuestRegionContainer`, a generic container of `GuestMemoryRegion`s, generalizing `GuestMemoryMmap` (which 
   is now a type alias for `GuestRegionContainer<GuestRegionMmap>`).
 - \[[#338](https://github.com/rust-vmm/vm-memory/pull/338)\] Make `GuestMemoryAtomic` always implement `Clone`.
+- \[[#338](https://github.com/rust-vmm/vm-memory/pull/338)\] Make `GuestAddressSpace` a subtrait of `Clone`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - \[[#311](https://github.com/rust-vmm/vm-memory/pull/311)\] Allow compiling without the ReadVolatile and WriteVolatile implementations
 - \[[#312](https://github.com/rust-vmm/vm-memory/pull/312)\] `GuestRegionContainer`, a generic container of `GuestMemoryRegion`s, generalizing `GuestMemoryMmap` (which 
   is now a type alias for `GuestRegionContainer<GuestRegionMmap>`).
+- \[[#338](https://github.com/rust-vmm/vm-memory/pull/338)\] Make `GuestMemoryAtomic` always implement `Clone`.
 
 ### Changed
 

--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -219,7 +219,7 @@ impl FileOffset {
 /// # }
 /// # }
 /// ```
-pub trait GuestAddressSpace {
+pub trait GuestAddressSpace: Clone {
     /// The type that will be used to access guest memory.
     type M: GuestMemory;
 


### PR DESCRIPTION
### Summary of the PR

The idea of `GuestAddressSpace` is that you would distribute as many references to it as needed.  However, `GuestAddressSpace` itself was not always cloneable because `GuestMemoryAtomic` uses `#[derive(Clone)]` which in turn requires *all type parameters* to be cloneable.

However, that is not a useful requirement for `GuestMemoryAtomic`, which is essentially an `Arc` wrapper. Fix that by implementing `Clone` by hand; this allows `GuestAddressSpace` to become a subtrait of `Clone` as well.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
