### PR TITLE
Configure cargo-all-features for CI to drop xen-specific custom tests

### DIFF
--- a/.buildkite/custom-tests.json
+++ b/.buildkite/custom-tests.json
@@ -4,14 +4,6 @@
       "test_name": "miri",
       "command": "RUST_BACKTRACE=1 MIRIFLAGS='-Zmiri-disable-isolation -Zmiri-backtrace=full' cargo +nightly miri test --features backend-mmap,backend-bitmap",
       "platform": ["x86_64", "aarch64"]
-    },
-    {
-      "test_name": "clippy-no-xen",
-      "command": "cargo clippy --workspace --bins --examples --benches  --features 'backend-bitmap backend-mmap backend-atomic' --all-targets -- -D warnings -D clippy::undocumented_unsafe_blocks",
-      "platform": [
-        "x86_64",
-        "aarch64"
-      ]
     }
   ]
 }

--- a/.buildkite/custom-tests.json
+++ b/.buildkite/custom-tests.json
@@ -1,57 +1,13 @@
 {
   "tests": [
     {
-      "test_name": "build-gnu-mmap",
-      "command": "cargo build --release --features=xen",
-      "platform": ["x86_64", "aarch64"]
-    },
-    {
-      "test_name": "build-gnu-mmap-no-xen",
-      "command": "cargo build --release --features=backend-mmap",
-      "platform": ["x86_64", "aarch64"]
-    },
-    {
-      "test_name": "build-musl-mmap",
-      "command": "cargo build --release --features=xen --target {target_platform}-unknown-linux-musl",
-      "platform": ["x86_64", "aarch64"]
-    },
-    {
-      "test_name": "build-musl-mmap-no-xen",
-      "command": "cargo build --release --features=backend-mmap --target {target_platform}-unknown-linux-musl",
-      "platform": ["x86_64", "aarch64"]
-    },
-    {
       "test_name": "miri",
       "command": "RUST_BACKTRACE=1 MIRIFLAGS='-Zmiri-disable-isolation -Zmiri-backtrace=full' cargo +nightly miri test --features backend-mmap,backend-bitmap",
       "platform": ["x86_64", "aarch64"]
     },
     {
-      "test_name": "unittests-gnu-no-xen",
-      "command": "cargo test --features 'backend-bitmap backend-mmap backend-atomic' --workspace",
-      "platform": [
-        "x86_64",
-        "aarch64"
-      ]
-    },
-    {
-      "test_name": "unittests-musl-no-xen",
-      "command": "cargo test  --features 'backend-bitmap backend-mmap backend-atomic' --workspace --target {target_platform}-unknown-linux-musl",
-      "platform": [
-        "x86_64",
-        "aarch64"
-      ]
-    },
-    {
       "test_name": "clippy-no-xen",
       "command": "cargo clippy --workspace --bins --examples --benches  --features 'backend-bitmap backend-mmap backend-atomic' --all-targets -- -D warnings -D clippy::undocumented_unsafe_blocks",
-      "platform": [
-        "x86_64",
-        "aarch64"
-      ]
-    },
-    {
-      "test_name": "check-warnings-no-xen",
-      "command": "RUSTFLAGS=\"-D warnings\" cargo check --all-targets  --features 'backend-bitmap backend-mmap backend-atomic' --workspace",
       "platform": [
         "x86_64",
         "aarch64"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,6 @@ codegen-units = 1
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[package.metadata.cargo-all-features]
+skip_optional_dependencies = true

--- a/benches/mmap/mod.rs
+++ b/benches/mmap/mod.rs
@@ -7,8 +7,11 @@
 extern crate criterion;
 extern crate vm_memory;
 
+#[cfg(feature = "rawfd")]
 use std::fs::{File, OpenOptions};
 use std::mem::size_of;
+
+#[cfg(feature = "rawfd")]
 use std::path::Path;
 
 use core::hint::black_box;
@@ -84,7 +87,10 @@ pub fn benchmark_for_mmap(c: &mut Criterion) {
 
     let mut image = make_image(ACCESS_SIZE);
     let buf = &mut [0u8; ACCESS_SIZE];
+
+    #[cfg(feature = "rawfd")]
     let mut file = File::open(Path::new("/dev/zero")).expect("Could not open /dev/zero");
+    #[cfg(feature = "rawfd")]
     let mut file_to_write = OpenOptions::new()
         .write(true)
         .open("/dev/null")
@@ -110,6 +116,7 @@ pub fn benchmark_for_mmap(c: &mut Criterion) {
             })
         });
 
+        #[cfg(feature = "rawfd")]
         c.bench_function(format!("read_from_file_{:#0X}", offset).as_str(), |b| {
             b.iter(|| {
                 black_box(&memory)
@@ -159,6 +166,7 @@ pub fn benchmark_for_mmap(c: &mut Criterion) {
             })
         });
 
+        #[cfg(feature = "rawfd")]
         c.bench_function(format!("write_to_file_{:#0X}", offset).as_str(), |b| {
             b.iter(|| {
                 black_box(&memory)

--- a/src/mmap/mod.rs
+++ b/src/mmap/mod.rs
@@ -171,7 +171,7 @@ impl<B: Bitmap> GuestMemoryRegionBytes for GuestRegionMmap<B> {}
 /// virtual address space of the calling process.
 pub type GuestMemoryMmap<B = ()> = GuestRegionCollection<GuestRegionMmap<B>>;
 
-/// Errors that can happen during [`GuestMemoryMap::from_ranges`] and related functions.
+/// Errors that can happen during [`GuestMemoryMmap::from_ranges`] and related functions.
 #[derive(Debug, thiserror::Error)]
 pub enum FromRangesError {
     /// Error during construction of [`GuestMemoryMmap`]


### PR DESCRIPTION
### Summary of the PR

With rust-vmm/rust-vmm-ci#192 switching our default tests to use cargo-all-features, we no longer need special test steps in custom-tests.json to work around the non-additive nature of the xen feature.

Unfortunately, there is no `cargo all-features clippy`, so removal of that one will need to wait until #317.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
