### PR TITLE
fix(doc): un-break docs.rs build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 #![warn(clippy::doc_markdown)]
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 // We only support 64bit. Fail build when attempting to build other targets
 #[cfg(not(target_pointer_width = "64"))]


### PR DESCRIPTION
the `doc_auto_cfg` feature has been merged into `doc_cfg` [1], and this is breaking building vm-memory documentation on docs.rs [2].

[1]: https://github.com/rust-lang/rust/pull/138907
[2]: https://docs.rs/crate/vm-memory/0.17.0/builds/2564760

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
