### PR TITLE
clippy: allow mut_from_ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - \[[#327](https://github.com/rust-vmm/vm-memory/pull/327)\] I/O virtual memory support via `IoMemory`, `IommuMemory`, and `Iommu`/`Iotlb`
 
+### Fixed
+
+- \[[#361](https://github.com/rust-vmm/vm-memory/pull/361)\] clippy: allow mut_from_ref
+
 ## \[v0.17.1\]
 
 No visible changes.

--- a/src/volatile_memory.rs
+++ b/src/volatile_memory.rs
@@ -228,6 +228,9 @@ pub trait VolatileMemory {
     ///
     /// If the resulting pointer is not aligned, this method will return an
     /// [`Error`](enum.Error.html).
+    // the function is unsafe, and the conversion is safe if following the safety
+    // instrutions above
+    #[allow(clippy::mut_from_ref)]
     unsafe fn aligned_as_mut<T: ByteValued>(&self, offset: usize) -> Result<&mut T> {
         let slice = self.get_slice(offset, size_of::<T>())?;
         slice.check_alignment(align_of::<T>())?;


### PR DESCRIPTION
### Summary of the PR

The purpose of the function is exactly to change a pointer obtained from a mutable VolatileSlice into a reference, and doing so is unsafe.  So just shut up clippy.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
