### PR TITLE
Have SimpleIommu depend on backend-mmap

### DIFF
--- a/src/iommu.rs
+++ b/src/iommu.rs
@@ -661,7 +661,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{Error, IotlbIterator, IovaRange, MappedRange};
+    #[cfg(feature = "backend-mmap")]
+    use super::IotlbIterator;
+    use super::{Error, IovaRange, MappedRange};
     #[cfg(all(feature = "backend-bitmap", feature = "backend-mmap"))]
     use crate::bitmap::AtomicBitmap;
     #[cfg(feature = "backend-mmap")]
@@ -670,17 +672,20 @@ mod tests {
     use crate::GuestMemoryRegion;
     #[cfg(feature = "backend-mmap")]
     use crate::{
-        Bytes, GuestMemoryError, GuestMemoryMmap, GuestMemoryResult, IoMemory, IommuMemory,
+        Bytes, GuestMemoryError, GuestMemoryMmap, GuestMemoryResult, IoMemory, Iommu, IommuMemory,
     };
-    use crate::{GuestAddress, Iommu, Iotlb, Permissions};
+    use crate::{GuestAddress, Iotlb, Permissions};
     use std::fmt::Debug;
     #[cfg(all(feature = "backend-bitmap", feature = "backend-mmap"))]
     use std::num::NonZeroUsize;
     use std::ops::Deref;
+    #[cfg(feature = "backend-mmap")]
     use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+    #[cfg(feature = "backend-mmap")]
     use std::sync::{RwLock, RwLockReadGuard};
 
     #[derive(Debug)]
+    #[cfg(feature = "backend-mmap")]
     struct SimpleIommu {
         iotlb: RwLock<Iotlb>,
         /// Records the last fail event's base IOVA
@@ -693,8 +698,8 @@ mod tests {
         next_map_to: AtomicU64,
     }
 
+    #[cfg(feature = "backend-mmap")]
     impl SimpleIommu {
-        #[cfg(feature = "backend-mmap")]
         fn new() -> Self {
             SimpleIommu {
                 iotlb: Iotlb::new().into(),
@@ -705,7 +710,6 @@ mod tests {
             }
         }
 
-        #[cfg(feature = "backend-mmap")]
         fn expect_mapping_request(&self, to_phys: GuestAddress) {
             // Clear failed range info so it can be tested after the request
             self.fail_base.store(0, Ordering::Relaxed);
@@ -713,7 +717,6 @@ mod tests {
             self.next_map_to.store(to_phys.0, Ordering::Relaxed);
         }
 
-        #[cfg(feature = "backend-mmap")]
         fn verify_mapping_request(&self, virt: GuestAddress, len: usize, was_miss: bool) {
             assert_eq!(self.fail_base.load(Ordering::Relaxed), virt.0);
             assert_eq!(self.fail_len.load(Ordering::Relaxed), len);
@@ -721,6 +724,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "backend-mmap")]
     impl Iommu for SimpleIommu {
         type IotlbGuard<'a> = RwLockReadGuard<'a, Iotlb>;
 


### PR DESCRIPTION
### Summary of the PR

`SimpleIommu` (part of the iommu.rs test module) is used only by `create_virt_memory()`, which in turn depends on the backend-mmap feature.  Have `SimpleIommu` as a whole depend on it, too.

(Reported by @roypat in #363)

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test. *(No functionality added/changed)*
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
  *(Nothing changed from last release)*
- [x] Any newly added `unsafe` code is properly documented. *(None there)*
