### PR TITLE
GuestAddressSpace: Make usable for 0.17 users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Upcoming version
+
+### Fixed
+
+- \[[#369](https://github.com/rust-vmm/vm-memory/pull/369)\] Make `GuestAddressSpace` usable for 0.17 users
+
 ## \[v0.17.2\]
 
 This release re-packages the code of vm-memory 0.18.0 while preserving

--- a/coverage_config_aarch64.json
+++ b/coverage_config_aarch64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 0.0,
+  "coverage_score": 100.0,
   "exclude_path": "mmap/windows.rs",
   "crate_features": "backend-mmap,backend-atomic,backend-bitmap"
 }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 0.0,
+  "coverage_score": 100.0,
   "exclude_path": "mmap_windows.rs",
   "crate_features": "backend-mmap,backend-atomic,backend-bitmap"
 }

--- a/src/guest_memory.rs
+++ b/src/guest_memory.rs
@@ -41,8 +41,133 @@
 //! via pointers, references, or slices returned by methods of `GuestMemory`,`GuestMemoryRegion`,
 //! `VolatileSlice`, `VolatileRef`, or `VolatileArrayRef`.
 
+use std::ops::Deref;
+use vm_memory_new::guest_memory::GuestAddressSpace as NewGuestAddressSpace;
 pub use vm_memory_new::guest_memory::{
-    Error, FileOffset, GuestAddress, GuestAddressSpace, GuestMemoryBackend as GuestMemory,
+    Error, FileOffset, GuestAddress, GuestMemoryBackend as GuestMemory,
     GuestMemoryBackendSliceIterator as GuestMemorySliceIterator, GuestUsize, MemoryRegionAddress,
     Result,
 };
+
+/// `GuestAddressSpace` provides a way to retrieve a `GuestMemory` object.
+/// The vm-memory crate already provides trivial implementation for
+/// references to `GuestMemory` or reference-counted `GuestMemory` objects,
+/// but the trait can also be implemented by any other struct in order
+/// to provide temporary access to a snapshot of the memory map.
+///
+/// In order to support generic mutable memory maps, devices (or other things
+/// that access memory) should store the memory as a `GuestAddressSpace<M>`.
+/// This example shows that references can also be used as the `GuestAddressSpace`
+/// implementation, providing a zero-cost abstraction whenever immutable memory
+/// maps are sufficient.
+///
+/// # Examples (uses the `backend-mmap` and `backend-atomic` features)
+///
+/// ```
+/// # #[cfg(feature = "backend-mmap")]
+/// # {
+/// # use std::sync::Arc;
+/// # use vm_memory::{GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryMmap};
+/// #
+/// pub struct VirtioDevice<AS: GuestAddressSpace> {
+///     mem: Option<AS>,
+/// }
+///
+/// impl<AS: GuestAddressSpace> VirtioDevice<AS> {
+///     fn new() -> Self {
+///         VirtioDevice { mem: None }
+///     }
+///     fn activate(&mut self, mem: AS) {
+///         self.mem = Some(mem)
+///     }
+/// }
+///
+/// fn get_mmap() -> GuestMemoryMmap<()> {
+///     let start_addr = GuestAddress(0x1000);
+///     GuestMemoryMmap::from_ranges(&vec![(start_addr, 0x400)])
+///         .expect("Could not create guest memory")
+/// }
+///
+/// // Using `VirtioDevice` with an immutable GuestMemoryMmap:
+/// let mut for_immutable_mmap = VirtioDevice::<&GuestMemoryMmap<()>>::new();
+/// let mmap = get_mmap();
+/// for_immutable_mmap.activate(&mmap);
+/// let mut another = VirtioDevice::<&GuestMemoryMmap<()>>::new();
+/// another.activate(&mmap);
+///
+/// # #[cfg(feature = "backend-atomic")]
+/// # {
+/// # use vm_memory::GuestMemoryAtomic;
+/// // Using `VirtioDevice` with a mutable GuestMemoryMmap:
+/// let mut for_mutable_mmap = VirtioDevice::<GuestMemoryAtomic<GuestMemoryMmap<()>>>::new();
+/// let atomic = GuestMemoryAtomic::new(get_mmap());
+/// for_mutable_mmap.activate(atomic.clone());
+/// let mut another = VirtioDevice::<GuestMemoryAtomic<GuestMemoryMmap<()>>>::new();
+/// another.activate(atomic.clone());
+///
+/// // atomic can be modified here...
+/// # }
+/// # }
+/// ```
+pub trait GuestAddressSpace: Clone {
+    /// The type that will be used to access guest memory.
+    type M: GuestMemory;
+
+    /// A type that provides access to the memory.
+    type T: Clone + Deref<Target = Self::M>;
+
+    /// Return an object (e.g. a reference or guard) that can be used
+    /// to access memory through this address space.  The object provides
+    /// a consistent snapshot of the memory map.
+    fn memory(&self) -> Self::T;
+}
+
+impl<M: NewGuestAddressSpace<M: GuestMemory>> GuestAddressSpace for M {
+    type M = M::M;
+    type T = M::T;
+
+    fn memory(&self) -> Self::T {
+        NewGuestAddressSpace::memory(self)
+    }
+}
+
+#[cfg(all(test, feature = "backend-atomic", feature = "backend-mmap"))]
+mod tests {
+    use crate::{GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic, GuestMemoryMmap};
+    use std::ops::Deref;
+
+    /// Simple memory user encapsulating a `GuestAddressSpace` object.
+    struct TestMemoryUser<M: GuestAddressSpace>(M);
+
+    impl<M: GuestAddressSpace> TestMemoryUser<M> {
+        fn new(memory: M) -> Self {
+            TestMemoryUser(memory)
+        }
+
+        /// Assert that `self.0` has exactly `reference` memory regions.
+        ///
+        /// This verifies that `GuestAddressSpace::memory()` returns something we can actually use,
+        /// i.e. that its memory type implements the `GuestMemory` trait as exported in 0.17, and
+        /// not the `GuestMemory` trait from 0.18, which is not available in 0.17 and is thus
+        /// unusable.
+        ///
+        /// (`.num_regions()` is just a simple way to verify the `GuestMemory` trait.)
+        fn check_region_count(&self, reference: usize) {
+            /// This inner function makes the trait requirement (`GuestMemory`) explicit.
+            fn do_check_region_count(mem: impl Deref<Target: GuestMemory>, reference: usize) {
+                assert_eq!(mem.num_regions(), reference);
+            }
+
+            do_check_region_count(self.0.memory(), reference);
+        }
+    }
+
+    /// Verify that `GuestAddressSpace::memory()` returns a usable type, i.e one whose
+    /// `Deref::Target` implements the `GuestMemory` trait that is actually exported in 0.17.
+    #[test]
+    fn test_guest_address_space_memory_access() {
+        let mem = GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap();
+        let user = TestMemoryUser::new(GuestMemoryAtomic::new(mem));
+        user.check_region_count(1);
+    }
+}


### PR DESCRIPTION
### Summary of the PR

(Preface: By e.g. `0.18::GuestMemory`, I mean the `GuestMemory` type from 0.18.)

`GuestAddressSpace` needs `M: 0.18::GuestMemory`, but to be usable in projects that depend on 0.17, it should guarantee `M: 0.17::GuestMemory` (i.e. `GuestMemoryBackend`).

The current bound breaks the vhost-user-backend crate, whose vring types require some type `M: GuestAddressSpace` with the expectation that `M::memory()` will return something that derefs to an `0.17::GuestMemory`.

To make this work, drop the `GuestAddressSpace` re-export and instead provide the trait from scratch with the `M: 0.17::GuestMemory` bound, and then provide a blanket implementation for all `0.18::GuestAddressSpace` with `M: 0.17::GuestMemory`.

I considered making `GuestAddressSpace: NewGuestAddressSpace` so that `0.17::GuestAddressSpace` types can be used where
`0.18::GuestAddressSpace` is required, but that would prohibit 0.17 users from implementing `GuestAddressSpace` on their own types, because they would need to implement `0.18::GuestAddressSpace` first.  That would be a breaking change, which we can’t have within 0.17.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
